### PR TITLE
Add OutcomeReview Pydantic model for post-mortem agent

### DIFF
--- a/src/outcome_review_agent/models.py
+++ b/src/outcome_review_agent/models.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class OutcomeReview(BaseModel):
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    trade_id: str = Field(
+        ...,
+        min_length=1,
+        description="Unique identifier for the settled trade.",
+    )
+    classification: Literal[
+        "deserved success",
+        "good failure",
+        "dumb luck",
+        "poetic justice",
+    ] = Field(
+        ...,
+        description="Outcome quadrant classification based on process quality and result quality.",
+    )
+    process_score: int = Field(
+        ...,
+        ge=0,
+        le=10,
+        description="How well the agents followed the strategy from 0 to 10.",
+    )
+    outcome_score: int = Field(
+        ...,
+        ge=0,
+        le=10,
+        description="Outcome quality based on simulated profit/loss from 0 to 10.",
+    )
+    new_info_impact: str = Field(
+        ...,
+        min_length=1,
+        description="What emerged after entry that the model missed.",
+    )
+    confidence_in_classification: int = Field(
+        ...,
+        ge=0,
+        le=100,
+        description="Confidence in this classification from 0 to 100.",
+    )
+    explanation: str = Field(
+        ...,
+        min_length=1,
+        description="Concise explanation of why this outcome fits the selected quadrant.",
+    )
+    strategy_adjustment_needed: bool = Field(
+        ...,
+        description="True if this indicates a systemic flaw, False if this was statistical noise.",
+    )


### PR DESCRIPTION
### Motivation
- Define a strict schema for the Post-Mortem/Outcome Review agent to standardize settled-trade reviews and enable downstream validation and serialization.

### Description
- Added `src/outcome_review_agent/models.py` containing a new `OutcomeReview` Pydantic model. 
- The model includes `trade_id`, `classification` (Literal of the four quadrants), `process_score`, `outcome_score`, `new_info_impact`, `confidence_in_classification`, `explanation`, and `strategy_adjustment_needed` fields. 
- Field constraints enforce ranges (`process_score`/`outcome_score` 0–10, `confidence_in_classification` 0–100), non-empty strings where required, and `classification` limited to the four requested literals. 
- Model is strict with `model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")` to prevent unexpected fields and trim whitespace.

### Testing
- Ran `python -m py_compile src/outcome_review_agent/models.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e9474289cc83229dfa1d121320bbd9)