### PR TITLE
Profitability pivot: honest fees, crypto 1m kill, shadow PnL ledger + Polymarket arb (T1-T8)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -107,6 +107,35 @@ Last updated: 2026-05-08 (post-Wave-1 + Lane D in flight + E4 regime memory part
 
 ---
 
+## Profitability Pivot (CEO review 2026-05-31)
+
+Strategic record: `docs/PROFITABILITY_PIVOT.md`. Crypto kill arithmetic: `docs/CRYPTO_1M_KILL.md`.
+Decision: **kill the crypto 1m directional stack** (predicted edge +10–20bps < ~120bps Coinbase
+round-trip — unprofitable by arithmetic), **freeze ~80% of the infra**, and **lead with model-free
+Polymarket arbitrage**, proven in shadow before any capital.
+
+Phase 0 — foundation (the rung-0 validate/kill tools):
+- **T1 honest fees in simulator** — ✅ DONE (`5f1db49`). `from_coinbase_fees()` wires 60/40bps.
+- **T2 backtest gate persists verdict** — ✅ DONE (`5f1db49`). `profit_report.json` now carries `gate_passed`/`gate_verdict`.
+- **T3 shadow PnL ledger** — ✅ DONE (`94eda08`). `src/state/pnl_ledger.py`, append-only, no-look-ahead guard.
+- **T4 documented crypto kill** — ✅ DONE (`5f1db49`). Deterministic test + `docs/CRYPTO_1M_KILL.md`.
+- **T5 freeze + governance norm** — ✅ DONE. "No new subsystem without a validated edge it serves." Frozen: `loss_postmortem`, `regime_memory`, `llm_strategy_gen`, extra adapters, D3, Grafana.
+
+Phase 1 — model-free arbitrage edge (SHADOW only, no execution):
+- **T6 honest directional EV helper** — ✅ DONE (`42f3ed2`). Warns: `fair_prob` is a MOCK until a real forecaster is validated.
+- **T7 intra-market arb detector** — ✅ DONE (`42f3ed2`). `src/arb_detector.py` YES+NO<$1 net of fee/gas, logs shadow candidates to the ledger.
+- **T8 read-only Kalshi feed** — ✅ DONE (`94eda08`). `src/exchanges/kalshi_market_data.py` for cross-venue gaps. Base URL/auth need live verification.
+- **T9 run the closed-loop shadow ledger 2–4 weeks** — ⏳ P1, ongoing. Prove arb survives real depth/latency/slippage before any capital. Needs live Polymarket (+Kalshi) order-book feeds wired into `scan_intramarket_arbs`.
+
+Phase 2 — execution (🔒 GATED: real money, explicit deliberate opt-in per Constitution; NOT built autonomously):
+- **T10 real Polymarket CLOB execution** — 🔒 P2. `polymarket_tradeable.py` is a stub; needs `py-clob-client` + signed orders + `get_balances` + settlement reader. Only after T9 shows positive net-of-fee edge.
+- **T11 strict size cap + self-slippage guard** — 🔒 P2. Reuse `risk_engine` Kelly/fee haircut; cap to ~$5–15k depth.
+- **T12 $50–100 live pilot** — 🔒 P2. Smallest real-money confirmation that fills match the shadow ledger. Scale only if they do.
+
+Explicitly deferred: LLM-forecasting edge (revisit only on thin/news-latency markets after arb pays — build the shadow loop so it's measurable); crypto funding-rate/basis arb on Hyperliquid (Phase 3 option).
+
+---
+
 ## How to use this file
 
 - **Humans mutate; agents read.** Agents may reference this file for context but should not edit without operator authorization (call it out in the brief if a backlog item is being closed).

--- a/docs/CRYPTO_1M_KILL.md
+++ b/docs/CRYPTO_1M_KILL.md
@@ -1,0 +1,153 @@
+# Kill Report — Crypto 1-Minute Directional XGBoost Stack
+
+**Date:** 2026-05-31
+**Decision:** FREEZE the crypto 1-minute directional stack until its economics change.
+**Why:** It is unprofitable by **arithmetic**, not by tuning. The edge it targets is
+smaller than the round-trip cost of the venue it would trade on.
+
+---
+
+## 1. The arithmetic
+
+The tier-2 crypto models are trained to predict a **+10–20 bps** move (the labels were
+relabeled to a +20 bps target — see commit `c4c86c1`, and `data/crypto/datasets/*_20bps.csv`).
+
+The repo's own live Coinbase adapter charges the **real** Coinbase Advanced retail fee:
+
+| Side  | Rate  | Source |
+|-------|-------|--------|
+| taker | 60 bps | `src/exchanges/adapters/coinbase_tradeable.py:54-56` — `FeeModel(maker=0.0040, taker=0.0060)` |
+| maker | 40 bps | same |
+
+Round-trip cost of actually executing a trade:
+
+| Path                | Cost      |
+|---------------------|-----------|
+| taker in + taker out | **~120 bps** |
+| taker in + maker out | ~100 bps  |
+| maker in + maker out | ~80 bps   |
+
+**A +20 bps target cannot clear a ~120 bps (or even ~80 bps) round-trip.** Every
+"winning" trade still loses money. No threshold, calibration, or confluence-gate tweak
+fixes a gross edge that is 4–6x smaller than cost. This is a unit-economics failure, full stop.
+
+---
+
+## 2. The bug that hid it: a ~7.5x fee understatement
+
+The real `FeeModel` (60/40 bps) was **defined but never wired into the simulator**. The
+backtester charged a fictional fee instead, so every backtest looked far better than reality:
+
+| Location | Before | After |
+|----------|--------|-------|
+| `trading/simulator.py` `SimulationConfig.fee_pct` default | `0.0008` (8 bps) | unchanged default `0.0008`, but a new honest constructor added (below) |
+| `trading/simulator.py` `SimulationConfig.maker_fee_pct` default | `None` → silently fell back to `fee_pct` in `_maker_fee_pct()`, so the maker path was also ~8 bps and **fictional** | now explicitly set by the honest constructor |
+| `src/backtest.py:239` | `fee_pct = 0.00075` (**7.5 bps**, hardcoded, even cheaper than the config default) and `maker_fee_pct` never set | removed; backtest now builds its config via `SimulationConfig.from_coinbase_fees()` |
+
+Effective round-trip cost charged by the simulator, measured directly
+(`tests/.../test_fee_honesty_kill.py::test_effective_round_trip_cost_is_about_120bps_under_coinbase`
+and `::test_old_cheap_default_understated_cost_at_about_16bps`):
+
+| Config | Round-trip cost |
+|--------|-----------------|
+| old cheap default (`fee_pct=0.0008`) | **16.00 bps** |
+| `from_coinbase_fees()` (real 60/40) | **120.00 bps** |
+
+That is a **7.5x** understatement. The old backtests were fictional; they "passed" because
+they were charging ~1/7th of real cost. This violated the Constitution's honest-reporting and
+no-look-ahead standards.
+
+### The fix (file:line)
+
+- `trading/simulator.py:23-25` — added `COINBASE_TAKER_FEE_PCT = 0.0060` / `COINBASE_MAKER_FEE_PCT = 0.0040`, mirroring the live adapter.
+- `trading/simulator.py:90-120` — added `SimulationConfig.from_coinbase_fees(...)`: sets `fee_pct = taker` (60 bps) **and** `maker_fee_pct = maker` (40 bps) so the maker leg is no longer fictional. The legacy `0.0008` default is kept for non-Coinbase/legacy callers.
+- `trading/simulator.py:122-138` — added `SimulationConfig.from_fee_model(fee_model)`: duck-typed on `.maker`/`.taker`, accepts the live adapters' `protocols.FeeModel` directly.
+- `src/backtest.py:239-264` — deleted the hardcoded `fee_pct = 0.00075`; the simulator config is now built with `SimulationConfig.from_coinbase_fees(...)`, so the backtest charges real Coinbase fees **by default**.
+
+### Optimistic-fill flag (not fixed, just flagged)
+
+`trading/simulator.py:470-479` — the post-only/maker entry path treats a limit posted at
+this bar's open as **filled** if the *same* bar's low/high crosses it. That is an optimistic
+same-bar look-ahead (real resting limits need price to return to them later in the bar, and
+queue position isn't guaranteed). Per scope, the fill engine was not rewritten; the assumption
+is now flagged in code so it is not silently relied on. It only inflates maker fill rates — it
+does not touch the fee arithmetic above, which already kills the stack on cost alone.
+
+---
+
+## 3. Deterministic evidence (env-independent)
+
+`tests/prediction_market_scanner/test_fee_honesty_kill.py` proves the kill without any data,
+model, or network. It constructs a trade that **perfectly hits the +20 bps target** and runs
+it through the simulator under real Coinbase taker fees:
+
+```
+Start capital            : $10,000.00
+Entry (taker, 60 bps)    : -$60.00
+Gross move (+20 bps)     : +$20.00
+Exit  (taker, 60 bps)    : -$60.00
+-----------------------------------
+Net PnL                  : -$100.00   (a WINNING +20 bps trade still loses ~100 bps)
+```
+
+Key asserts (all passing):
+- A perfect +20 bps winner nets **−$100** (negative) under real Coinbase taker fees.
+- Effective round-trip cost is **~120 bps** under Coinbase config, vs **~16 bps** under the old cheap default.
+- Control: the *same* +20 bps winner is **profitable (+$4)** under the old cheap fees — proving the kill is driven by the fee correction, not a rigged scenario.
+
+Run:
+```
+env PYTHONPATH=src ./.venv/bin/python -m unittest \
+    tests.prediction_market_scanner.test_fee_honesty_kill -v
+# Ran 7 tests ... OK
+```
+
+---
+
+## 4. Real backtest attempt (timeboxed) — blocked, deterministic test stands in
+
+A real ETH backtest was attempted on `data/crypto/datasets/eth_usd_1m.csv` (129k rows) but
+was **blocked by a missing model artifact**: `model_sanity/` ships `model_meta.json` +
+`scaler.joblib` but **no `model.pt` weights** (`FileNotFoundError: model_sanity/model.pt`).
+Model weights are generated artifacts and are not checked in (per `CLAUDE.md`). The data also
+spans only ~3 months from 2026-02-22, short of the 6+3-month walk-forward minimum
+(`src/backtest.py` raises `"Not enough data for 6+3 month walk-forward"` for <9 months).
+
+Rather than fight the environment, the **deterministic unit test in §3 is the canonical
+evidence**. It is stronger than a single backtest anyway: it isolates the fee arithmetic from
+model quality and data noise, and it is reproducible on any machine with no torch, no TA-Lib,
+no data, and no network.
+
+The backtest gate itself was confirmed and completed (T2): `src/backtest.py` persists
+`profit_report.json` and now records an explicit `gate_passed` / `gate_verdict` from the
+PF ≥ 1.8 and max-drawdown ≤ 10% reject gate, computed on the honest fees
+(`src/backtest.py:509-535`).
+
+---
+
+## 5. Decision
+
+**FREEZE** the crypto 1-minute directional stack. Do not run it live, and do not treat its
+historical backtests as valid — they were computed on a ~7.5x cost understatement.
+
+It may be **unfrozen only** when its economics actually change, i.e. one of:
+
+1. **Longer-horizon labels** whose realized gross edge comfortably exceeds ~120 bps
+   round-trip (e.g. multi-hour / daily moves, not 1-minute +20 bps), **or**
+2. **A maker-rebate or low-fee venue** where the round-trip cost drops below the model's
+   gross edge — and only if the simulator's optimistic same-bar maker fill (§2) is replaced
+   with a realistic resting-limit fill model first, since a maker-only strategy lives or
+   dies on fill realism.
+
+Until then, capital and engineering effort belong on surfaces where edge > cost — which,
+under the mission, means the prediction-market and cross-venue work, not 1-minute crypto
+direction.
+
+---
+
+### Files changed by this kill
+
+- `trading/simulator.py` — honest Coinbase fee constants + `from_coinbase_fees()` / `from_fee_model()` constructors; optimistic-fill flagged.
+- `src/backtest.py` — backtest now charges real Coinbase fees by default; `profit_report.json` gate verdict persisted.
+- `tests/prediction_market_scanner/test_fee_honesty_kill.py` — deterministic kill proof (7 tests).
+- `docs/CRYPTO_1M_KILL.md` — this report.

--- a/docs/PROFITABILITY_PIVOT.md
+++ b/docs/PROFITABILITY_PIVOT.md
@@ -1,0 +1,77 @@
+# Profitability Pivot — 2026-05-31
+
+Outcome of a CEO/quant review of the whole project. This is the strategic record;
+`docs/CRYPTO_1M_KILL.md` holds the crypto arithmetic; `TODOS.md` holds the task backlog.
+
+## Verdict (one line)
+
+Freeze ~80% of the infra, build the cost-aware backtest + PnL ledger, kill the crypto
+1m directional stack on documented evidence, and prove a **model-free Polymarket
+arbitrage** edge in shadow before spending a dollar.
+
+## Why the crypto 1m stack was killed (arithmetic, not tuning)
+
+- Models predict a **+10–20bps** move. The repo's own Coinbase adapter charges
+  **60bps taker / 40bps maker = ~120bps round-trip** (`coinbase_tradeable.py` FeeModel).
+  The predicted edge is **6–12x smaller than the cost to capture it.** No model quality
+  fixes an edge-smaller-than-cost inequality.
+- The simulator was hiding this: it charged ~8–16bps while the real cost is ~120bps —
+  a ~7.5x understatement, with the maker path unwired. Fixed in
+  `trading/simulator.py` (`from_coinbase_fees()`), proven in
+  `tests/prediction_market_scanner/test_fee_honesty_kill.py` (a perfect +20bps winner
+  nets **−$100** at real fees, **+$4** at the old fake fees).
+- No `profit_report.json` has ever existed → no backtest ever produced a profitable,
+  validated model. The whole trading record is 3 SOL paper trades, all losses.
+
+## Where the money is (2026 landscape, researched)
+
+- **Crypto:** not directional ML. Market-neutral funding-rate/basis arb (~10–30% APY)
+  and maker-rebate market-making on low-fee venues (Hyperliquid 0.01% maker). Deferred.
+- **Prediction markets (the chosen arena):** model-free **cross-venue / intra-market
+  arbitrage** (YES+NO < $1; Polymarket-vs-Kalshi gaps) — doesn't require beating the
+  crowd. Plus liquidity-reward farming. Capacity-bounded (~$5–15k depth), which suits a
+  solo operator. The existing `risk_engine` already does cost-aware sizing honestly.
+
+## The ladder (where we are → where we go)
+
+```
+  rung 0: measure edge net of cost   <-- WE WERE HERE (no tool, no ledger)
+  rung 1: one backtested edge          <-- building the tooling now
+  rung 2: shadow track record beats market net of fees
+  rung 3: tiny live pilot ($50-100)
+  rung 4: scale within capacity
+```
+
+## What shipped this session (Phase 0 + buildable Phase 1, all SHADOW/no real money)
+
+| Task | What | Status |
+|------|------|--------|
+| T1 | Wire real Coinbase fees into the simulator | ✅ done |
+| T2 | Backtest persists gate verdict to profit_report.json | ✅ done |
+| T3 | Shadow PnL ledger (`src/state/pnl_ledger.py`, no-look-ahead guard) | ✅ done |
+| T4 | Documented crypto 1m kill (deterministic test + `docs/CRYPTO_1M_KILL.md`) | ✅ done |
+| T5 | Freeze + governance norm (this doc) | ✅ done |
+| T6 | Honest directional EV helper (warns: fair_prob is a MOCK today) | ✅ done |
+| T7 | Intra-market arb detector (`src/arb_detector.py`, shadow, logs to ledger) | ✅ done |
+| T8 | Read-only Kalshi market-data client (`src/exchanges/kalshi_market_data.py`) | ✅ done |
+| T9 | Run the closed-loop shadow ledger for 2–4 weeks (prove arb survives slippage) | ⏳ ongoing |
+| T10 | Real Polymarket CLOB execution (py-clob-client + signing) | 🔒 gated: explicit opt-in |
+| T11 | Strict size cap + self-slippage guard | 🔒 gated |
+| T12 | $50–100 live pilot | 🔒 gated: real money, Constitution opt-in |
+
+**Hard line:** T10–T12 move real money. Per the Constitution (paper default, live = explicit
+deliberate opt-in), they were NOT built autonomously and require a deliberate human go.
+
+## Frozen until rung 1 (one validated edge)
+
+`loss_postmortem` (forensics swarm), `regime_memory`, `llm_strategy_gen`, the multi-asset
+adapters beyond Polymarket/Kalshi, the D3 multiprocessing-supervisor refactor, and the
+Grafana dashboard. They are rung-3-to-5 tooling for an edge that does not exist yet.
+
+## Governance norm (working rule, not a Constitution amendment)
+
+**No new subsystem without a validated edge it serves.** New strategy code must clear the
+cost-aware backtest / shadow ledger before it earns more infrastructure. This concentrates
+the scarce resource — operator/agent attention — on finding the first profitable dollar.
+(This adds discipline; it does not change the locked Constitution standards, so it needs no
+`GETTINGAJET`.)

--- a/src/arb_detector.py
+++ b/src/arb_detector.py
@@ -1,0 +1,452 @@
+"""Model-free arbitrage detection for binary prediction markets (SHADOW-ONLY).
+
+This module is the first *real* profit path for the prediction-market stack. It
+does NOT depend on a forecaster — that is the whole point. The scanner's
+``research_priority`` (``src/ranker.py``) ranks markets by how *interesting* they
+are to research; it never computes mispricing or expected value. The calibration
+"edge" is currently a MOCK (``calibration_agent/ml_service.py`` returns
+``implied_prob + uniform(+/-0.02)``), so any LLM-vs-market directional edge today
+is noise. Intra-market arbitrage sidesteps all of that: it is a pure accounting
+identity on a binary market and needs no probability estimate at all.
+
+SAFETY (Constitution: safety first for anything that moves money)
+----------------------------------------------------------------
+This module is **SHADOW-ONLY**. It *detects* and *logs* opportunities. It places
+NO orders, signs nothing, and adds no execution path. When a :class:`PnlLedger`
+is passed to :func:`scan_intramarket_arbs`, opportunities are appended as
+``status='open'`` shadow :class:`TradeRecord`s so the closed loop (detect ->
+record -> later settle) can be audited with zero real exposure. Wiring real
+execution is explicitly out of scope here.
+
+The intra-market arbitrage identity
+------------------------------------
+On a Polymarket binary, the YES and NO tokens of the same market together pay
+out exactly ``$1`` at resolution: if the event happens YES pays $1 and NO pays
+$0; if it doesn't, NO pays $1 and YES pays $0. Either way the *pair* pays $1.
+
+So if you can BUY 1 YES at ``yes_ask`` and BUY 1 NO at ``no_ask`` for a combined
+cost of ``yes_ask + no_ask`` and you are guaranteed $1 back, then whenever::
+
+    yes_ask + no_ask < 1
+
+you have locked in a risk-free gross edge of ``1 - (yes_ask + no_ask)`` per $1 of
+payout, *before costs*. Costs that must be honestly netted out (Constitution:
+honest costs):
+
+* **Settlement fee** — Polymarket charges a fee on the winning payout at
+  resolution (~200 bps here). It applies to the $1 that comes back, so the fee in
+  dollars per pair is ``(settlement_fee_bps / 10_000) * 1.0``.
+* **Gas** — fixed on-chain cost per pair (USD), passed in by the caller.
+
+Net edge per pair is therefore::
+
+    net_edge_per_pair = gross_edge - settlement_fee_dollars - gas_usd
+
+and only a strictly-positive net edge is an arb.
+
+Costs are charged once *per pair*, and we report a per-pair cost basis of
+``yes_ask + no_ask`` (what you actually pay up front to acquire the pair). The
+gas term is *not* folded into ``cost_basis`` because cost_basis is the tradeable
+acquisition price of the pair; gas/fees are netted separately into the edge so
+the economics stay legible.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional
+
+try:  # Flat import under PYTHONPATH=src (matches the rest of the stack).
+    from state.pnl_ledger import PnlLedger, TradeRecord
+except Exception:  # pragma: no cover - only hit if ledger module is unavailable.
+    PnlLedger = Any  # type: ignore
+    TradeRecord = Any  # type: ignore
+
+
+logger = logging.getLogger(__name__)
+
+# Polymarket's resolution/settlement fee, in basis points, charged on the $1
+# winning payout. Kept as a module default so callers (and tests) can override.
+DEFAULT_SETTLEMENT_FEE_BPS = 200.0
+
+# A binary YES/NO pair always redeems for exactly $1 at resolution.
+GUARANTEED_PAYOUT_USD = 1.0
+
+# Field-name variants tolerated when reading a market dict. The scanner export
+# rows (see ``main.py`` EXPORT_FIELDS) and various venue adapters spell these
+# differently; map them all to the canonical (yes_ask, no_ask, id) here.
+_YES_ASK_KEYS = ("yes_ask", "yes_ask_price", "yesAsk", "ask_yes", "yes_price")
+_NO_ASK_KEYS = ("no_ask", "no_ask_price", "noAsk", "ask_no", "no_price")
+_ID_KEYS = ("market_id", "id", "ticker", "condition_id", "conditionId", "slug")
+
+
+def _settlement_fee_dollars(settlement_fee_bps: float) -> float:
+    """Dollar fee charged on the $1 winning payout for one YES+NO pair."""
+    return (float(settlement_fee_bps) / 10_000.0) * GUARANTEED_PAYOUT_USD
+
+
+def _validate_price(value: Any, label: str) -> float:
+    """Coerce ``value`` to a float price strictly inside ``(0, 1)``.
+
+    Prices at or beyond the bounds are rejected: ``<= 0`` is free money / a data
+    error, ``>= 1`` means the leg costs at least the whole guaranteed payout, so
+    neither is a tradeable ask on a binary market.
+    """
+    try:
+        price = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} is not a number: {value!r}") from exc
+    if not (0.0 < price < 1.0):
+        raise ValueError(f"{label} must be in the open interval (0, 1); got {price}")
+    return price
+
+
+def intramarket_arb(
+    yes_ask: float,
+    no_ask: float,
+    *,
+    settlement_fee_bps: float = DEFAULT_SETTLEMENT_FEE_BPS,
+    gas_usd: float = 0.0,
+    size_usd: float = 0.0,
+) -> Optional[Dict[str, Any]]:
+    """Detect a model-free intra-market arbitrage on one binary market.
+
+    Buying 1 YES + 1 NO on the same binary market guarantees a ``$1`` payout at
+    resolution. If the combined ask ``yes_ask + no_ask`` is below $1, the gap is
+    a locked gross edge; this nets it for the settlement fee (charged on the $1
+    payout) and gas, and returns the opportunity *only* if the net edge is
+    strictly positive.
+
+    Parameters
+    ----------
+    yes_ask, no_ask:
+        Ask (buy) prices of the YES and NO legs, each in the open interval
+        ``(0, 1)``. Validated; out-of-range or non-numeric inputs raise
+        :class:`ValueError`.
+    settlement_fee_bps:
+        Fee in basis points charged on the $1 winning payout at resolution
+        (default 200 bps). Converted to dollars-per-pair internally.
+    gas_usd:
+        Fixed on-chain execution cost per pair, in USD (default 0).
+    size_usd:
+        If > 0, treated as the dollar amount of guaranteed *payout* to acquire
+        (i.e. the number of YES+NO pairs, since each pair pays $1). Used only to
+        compute ``est_profit_usd``; it does not affect whether an arb exists.
+
+    Returns
+    -------
+    dict | None
+        ``None`` if there is no net-positive edge after costs. Otherwise a dict::
+
+            {
+                "gross_edge":        1 - (yes_ask + no_ask),
+                "net_edge_per_pair": gross_edge - fee$ - gas,
+                "net_edge_pct":      net_edge_per_pair / cost_basis,
+                "cost_basis":        yes_ask + no_ask,
+                "settlement_fee_usd": fee charged on the $1 payout per pair,
+                "gas_usd":           gas cost per pair,
+                "est_profit_usd":    net_edge_per_pair * n_pairs (if size_usd>0),
+                "legs": [{"side": "YES", "price": yes_ask},
+                         {"side": "NO",  "price": no_ask}],
+            }
+    """
+    yes_ask = _validate_price(yes_ask, "yes_ask")
+    no_ask = _validate_price(no_ask, "no_ask")
+
+    cost_basis = yes_ask + no_ask
+    gross_edge = GUARANTEED_PAYOUT_USD - cost_basis
+    if gross_edge <= 0.0:
+        # No gross edge: the pair costs at least the guaranteed payout.
+        return None
+
+    fee_usd = _settlement_fee_dollars(settlement_fee_bps)
+    gas = max(0.0, float(gas_usd))
+    net_edge_per_pair = gross_edge - fee_usd - gas
+    if net_edge_per_pair <= 0.0:
+        # Gross edge fully eaten by settlement fee + gas; not tradeable.
+        return None
+
+    # net_edge_pct is return-on-capital: profit per $1 of capital deployed to
+    # acquire the pair (cost_basis is what you pay up front).
+    net_edge_pct = net_edge_per_pair / cost_basis
+
+    result: Dict[str, Any] = {
+        "gross_edge": gross_edge,
+        "net_edge_per_pair": net_edge_per_pair,
+        "net_edge_pct": net_edge_pct,
+        "cost_basis": cost_basis,
+        "settlement_fee_usd": fee_usd,
+        "gas_usd": gas,
+        "est_profit_usd": 0.0,
+        "legs": [
+            {"side": "YES", "price": yes_ask},
+            {"side": "NO", "price": no_ask},
+        ],
+    }
+
+    if size_usd and float(size_usd) > 0.0:
+        # size_usd is the dollar amount of guaranteed $1 payout to acquire, i.e.
+        # the pair count (each pair redeems for exactly $1). Profit scales
+        # linearly in the number of pairs.
+        n_pairs = float(size_usd) / GUARANTEED_PAYOUT_USD
+        result["est_profit_usd"] = net_edge_per_pair * n_pairs
+
+    return result
+
+
+def _first_present(market: Dict[str, Any], keys: Iterable[str]) -> Any:
+    """Return the first value for any of ``keys`` present (not None) in ``market``."""
+    for key in keys:
+        if key in market and market[key] is not None:
+            return market[key]
+    return None
+
+
+def _market_identifier(market: Dict[str, Any]) -> str:
+    """Best-effort stable identifier for a market dict (tolerant of key drift)."""
+    ident = _first_present(market, _ID_KEYS)
+    return str(ident) if ident is not None else "unknown"
+
+
+def scan_intramarket_arbs(
+    markets: Iterable[Dict[str, Any]],
+    *,
+    ledger: "Optional[PnlLedger]" = None,
+    min_net_edge_pct: float = 0.005,
+    size_usd: float = 0.0,
+    strategy: str = "intramarket_arb",
+) -> List[Dict[str, Any]]:
+    """Scan an iterable of market dicts for intra-market arbitrage opportunities.
+
+    Each market dict must carry a YES ask and a NO ask. The reader is tolerant of
+    field-name variants:
+
+        * YES ask: one of ``{yes_ask, yes_ask_price, yesAsk, ask_yes, yes_price}``
+        * NO ask:  one of ``{no_ask, no_ask_price, noAsk, ask_no, no_price}``
+        * id:      one of ``{market_id, id, ticker, condition_id,
+                   conditionId, slug}`` (used only for labelling/logging)
+
+    Markets missing either ask, or whose asks fail price validation, are skipped
+    (logged at DEBUG) rather than raising — a scan over a noisy export should not
+    abort on one bad row.
+
+    Parameters
+    ----------
+    markets:
+        Iterable of market dicts (e.g. scanner export rows + explicit asks).
+    ledger:
+        Optional :class:`PnlLedger`. When provided, each detected opportunity is
+        appended as a SHADOW ``status='open'`` :class:`TradeRecord`
+        (``venue='polymarket'``, ``strategy=strategy``, ``side='YES+NO'``,
+        ``entry_price=cost_basis``, ``fees_usd=settlement_fee_usd + gas``). This
+        demonstrates the closed loop with **zero execution** — no order is placed.
+    min_net_edge_pct:
+        Minimum net edge (as a fraction of cost basis) to report. Default 0.5%.
+    size_usd:
+        Forwarded to :func:`intramarket_arb` for ``est_profit_usd`` and used as
+        the shadow record ``size`` (USD notional). 0 means size-agnostic.
+    strategy:
+        Strategy label stamped onto detected arbs and shadow records.
+
+    Returns
+    -------
+    list[dict]
+        Detected opportunities (each the :func:`intramarket_arb` dict plus
+        ``market_id`` and ``strategy``), sorted by ``net_edge_pct`` descending.
+    """
+    opportunities: List[Dict[str, Any]] = []
+
+    for market in markets:
+        if not isinstance(market, dict):
+            logger.debug("Skipping non-dict market row: %r", market)
+            continue
+
+        yes_raw = _first_present(market, _YES_ASK_KEYS)
+        no_raw = _first_present(market, _NO_ASK_KEYS)
+        if yes_raw is None or no_raw is None:
+            logger.debug(
+                "Skipping market %s: missing yes_ask/no_ask",
+                _market_identifier(market),
+            )
+            continue
+
+        try:
+            arb = intramarket_arb(
+                yes_raw,
+                no_raw,
+                settlement_fee_bps=float(market.get("settlement_fee_bps", DEFAULT_SETTLEMENT_FEE_BPS)),
+                gas_usd=float(market.get("gas_usd", 0.0)),
+                size_usd=size_usd,
+            )
+        except ValueError as exc:
+            logger.debug(
+                "Skipping market %s: invalid arb inputs (%s)",
+                _market_identifier(market),
+                exc,
+            )
+            continue
+
+        if arb is None or arb["net_edge_pct"] < float(min_net_edge_pct):
+            continue
+
+        market_id = _market_identifier(market)
+        arb = {**arb, "market_id": market_id, "strategy": strategy}
+        opportunities.append(arb)
+
+        if ledger is not None:
+            _append_shadow_record(
+                ledger,
+                arb,
+                market_id=market_id,
+                strategy=strategy,
+                size_usd=size_usd,
+            )
+
+    opportunities.sort(key=lambda a: a["net_edge_pct"], reverse=True)
+    return opportunities
+
+
+def _append_shadow_record(
+    ledger: "PnlLedger",
+    arb: Dict[str, Any],
+    *,
+    market_id: str,
+    strategy: str,
+    size_usd: float,
+) -> None:
+    """Append one SHADOW (status='open') TradeRecord for a detected arb.
+
+    SHADOW-ONLY: this records the opportunity in the audit ledger; it does not
+    and must not place any order. ``entry_price`` is the per-pair cost basis,
+    ``fees_usd`` is the per-pair settlement fee + gas, and the note flags this as
+    a shadow arb so any reader can see no capital was actually committed.
+    """
+    now_iso = datetime.now(timezone.utc).isoformat()
+    fees_usd = float(arb.get("settlement_fee_usd", 0.0)) + float(arb.get("gas_usd", 0.0))
+    trade_id = f"arb-{market_id}-{now_iso}"
+
+    record = TradeRecord(
+        trade_id=trade_id,
+        ts_utc=now_iso,
+        venue="polymarket",
+        market_id=market_id,
+        side="YES+NO",
+        entry_price=float(arb["cost_basis"]),
+        size=float(size_usd),
+        fees_usd=fees_usd,
+        slippage_bps=0.0,
+        strategy=strategy,
+        status="open",
+        notes=(
+            "SHADOW intra-market arb (NO order placed): "
+            f"gross={arb['gross_edge']:.4f} "
+            f"net_per_pair={arb['net_edge_per_pair']:.4f} "
+            f"net_pct={arb['net_edge_pct']:.4%}"
+        ),
+    )
+    ledger.append(record)
+
+
+def net_directional_edge(
+    fair_prob: float,
+    market_ask: float,
+    *,
+    settlement_fee_bps: float = DEFAULT_SETTLEMENT_FEE_BPS,
+    gas_usd: float = 0.0,
+) -> float:
+    """Expected value per $1 of buying YES at ``market_ask`` given ``fair_prob``.
+
+    WARNING (read before using this for anything):
+        ``fair_prob`` MUST come from a VALIDATED, non-mock forecaster. Today the
+        only probability source in this repo
+        (``calibration_agent/ml_service.get_xgboost_probability``) is a MOCK that
+        returns ``implied_prob + uniform(+/-0.02)`` — pure noise. Feeding that
+        here produces a number that *looks* like an edge but is not one. This
+        directional path is therefore NOT yet a real edge and must NOT be traded
+        until a shadow track record demonstrates it beats the market price net of
+        fees. The model-free :func:`intramarket_arb` is the only path that is
+        safe to act on today (and even that is shadow-only here).
+
+    Economics
+    ---------
+    Buy 1 YES at ``market_ask``. With probability ``fair_prob`` the event happens
+    and YES redeems for $1 (minus the settlement fee on that $1 payout); with
+    probability ``1 - fair_prob`` it redeems for $0. Expected value per unit::
+
+        EV = fair_prob * (1 - market_ask - settlement_fee$) + (1 - fair_prob) * (0 - market_ask) - gas
+           = fair_prob * (1 - settlement_fee$) - market_ask - gas
+
+    The settlement fee is only paid when YES wins (the payout case), so it is
+    weighted by ``fair_prob``. ``gas_usd`` is a fixed per-unit cost paid in both
+    outcomes.
+
+    Parameters
+    ----------
+    fair_prob:
+        Probability the YES outcome resolves true, in ``[0, 1]``.
+    market_ask:
+        Ask price to buy YES, in the open interval ``(0, 1)``.
+    settlement_fee_bps:
+        Fee in basis points on the $1 winning payout (default 200 bps).
+    gas_usd:
+        Fixed per-unit execution cost in USD (default 0).
+
+    Returns
+    -------
+    float
+        Net expected value per $1 of YES bought. Positive means a (claimed) edge;
+        negative means a losing buy after costs. May be negative.
+    """
+    if not (0.0 <= float(fair_prob) <= 1.0):
+        raise ValueError(f"fair_prob must be in [0, 1]; got {fair_prob}")
+    ask = _validate_price(market_ask, "market_ask")
+
+    fee_usd = _settlement_fee_dollars(settlement_fee_bps)
+    gas = max(0.0, float(gas_usd))
+    return float(fair_prob) * (GUARANTEED_PAYOUT_USD - fee_usd) - ask - gas
+
+
+def market_row_to_arb_input(
+    row: Dict[str, Any],
+    *,
+    no_ask: Optional[float] = None,
+) -> Optional[Dict[str, Any]]:
+    """Additive helper: map a scanner export row -> an arb-input dict.
+
+    Scanner export rows (``main.py`` EXPORT_FIELDS) carry ``implied_prob`` and
+    ``spread`` but NOT separate YES/NO asks, so they cannot by themselves prove an
+    intra-market arb. This helper is therefore *opt-in* and *additive*: it returns
+    ``None`` unless a NO ask is available (either already on the row under a
+    tolerated key, or passed explicitly via ``no_ask``).
+
+    When asks are not directly present, the YES ask is approximated as
+    ``implied_prob`` (mid) — callers should prefer feeding true book asks. The NO
+    leg must be supplied; we deliberately do NOT fabricate ``no_ask = 1 - yes_bid``
+    here, to avoid manufacturing phantom arbs from a single mid price.
+
+    Returns a dict with ``yes_ask``, ``no_ask`` and the row's id, or ``None`` if a
+    NO ask cannot be determined.
+    """
+    yes_ask = _first_present(row, _YES_ASK_KEYS)
+    if yes_ask is None:
+        implied = row.get("implied_prob")
+        if implied is not None:
+            yes_ask = implied
+    resolved_no = no_ask if no_ask is not None else _first_present(row, _NO_ASK_KEYS)
+    if yes_ask is None or resolved_no is None:
+        return None
+    return {
+        "market_id": _market_identifier(row),
+        "yes_ask": float(yes_ask),
+        "no_ask": float(resolved_no),
+    }
+
+
+__all__ = [
+    "DEFAULT_SETTLEMENT_FEE_BPS",
+    "GUARANTEED_PAYOUT_USD",
+    "intramarket_arb",
+    "scan_intramarket_arbs",
+    "net_directional_edge",
+    "market_row_to_arb_input",
+]

--- a/src/backtest.py
+++ b/src/backtest.py
@@ -236,7 +236,13 @@ class ProfitOptimizedBacktester:
         else:
             window_size = int(cfg.window_size or meta.get("window_size", DEFAULT_SEQ_LEN))
 
-        fee_pct = 0.00075
+        # HONEST COSTS: use the *real* Coinbase Advanced retail fee schedule
+        # (taker 60 bps / maker 40 bps) that the live adapter charges, instead of
+        # the old fictional 7.5 bps. The previous ``fee_pct = 0.00075`` understated
+        # round-trip cost by ~16x and left the maker path unwired, making every
+        # backtest fictional. ``from_coinbase_fees()`` wires BOTH sides.
+        # See trading/simulator.py COINBASE_*_FEE_PCT and
+        # src/exchanges/adapters/coinbase_tradeable.py _DEFAULT_COINBASE_FEE_MODEL.
         tp_pct = float(meta.get("tp_pct", cfg.tp_pct))
         sl_pct = float(meta.get("sl_pct", cfg.sl_pct))
 
@@ -249,9 +255,8 @@ class ProfitOptimizedBacktester:
 
         overlap_rows = max(window_size + 5, 2000)
 
-        sim_cfg = SimulationConfig(
+        sim_cfg = SimulationConfig.from_coinbase_fees(
             start_capital=float(cfg.capital),
-            fee_pct=fee_pct,
             tp_pct=tp_pct,
             sl_pct=sl_pct,
             cooldown=int(cfg.cooldown),
@@ -501,6 +506,14 @@ class ProfitOptimizedBacktester:
         )
         if ev < 0.0005 or pf < 1.4:
             print("\033[91mRETRAIN WITH PROFIT MODE — current model is not profitable enough\033[0m")
+
+        # Hard reject gate — these thresholds are computed on the HONEST Coinbase
+        # fee schedule (see _run_stream). A model only "passes" if it clears both
+        # the profit-factor floor and the drawdown ceiling. We persist the verdict
+        # into profit_report.json so the decision is auditable, not just printed.
+        gate_min_profit_factor = 1.8
+        gate_max_drawdown_pct = 10.0
+        gate_rejected = bool(pf < gate_min_profit_factor or max_dd > gate_max_drawdown_pct)
         report = {
             "ev_per_trade": ev,
             "expectancy": ev,
@@ -509,11 +522,15 @@ class ProfitOptimizedBacktester:
             "sharpe": sharpe,
             "win_rate_pct": win_rate,
             "recommendation": "Retrain recommended" if ev < 0.0005 else "Hold model",
+            "gate_min_profit_factor": gate_min_profit_factor,
+            "gate_max_drawdown_pct": gate_max_drawdown_pct,
+            "gate_passed": (not gate_rejected),
+            "gate_verdict": "REJECTED" if gate_rejected else "ACCEPTED",
         }
         report_path = Path(self.model_dir) / "profit_report.json"
         report_path.write_text(json.dumps(report, indent=2))
 
-        if final_metrics["profit_factor"] < 1.8 or final_metrics["max_drawdown_pct"] > 10.0:
+        if gate_rejected:
             print("UNPROFITABLE - REJECTED")
         else:
             update_strategy_registry(Path(self.model_dir), final_metrics.get("recovery_factor", 0.0))

--- a/src/exchanges/kalshi_market_data.py
+++ b/src/exchanges/kalshi_market_data.py
@@ -1,0 +1,302 @@
+"""Read-only Kalshi market-data client for cross-venue mispricing detection.
+
+This module is a thin, hermetic wrapper around Kalshi's public ``trade-api``
+v2 **market-data** endpoints. Its only job is to pull market metadata and
+order books so a later stage can compare Polymarket vs. Kalshi prices and
+flag cross-venue mispricing.
+
+SCOPE — READ-ONLY, NO MONEY MOVES:
+    This client intentionally exposes ONLY market-data reads
+    (``get_markets``, ``get_market``, ``get_orderbook``). It performs no
+    authentication-gated trade calls, places no orders, and writes nothing.
+    Do not add order placement, balance, or any signed/portfolio endpoints
+    here — those belong in a separate, deliberately opted-in trading client.
+
+LIVE-VERIFICATION CAVEAT (operator must confirm before relying on this):
+    * Base URL — defaults to ``https://api.elections.kalshi.com/trade-api/v2``.
+      Kalshi has historically also served ``https://trading-api.kalshi.com``
+      and demo hosts. The operator MUST confirm the *current* production base
+      URL for public market data before wiring this into anything live; it is
+      a constructor parameter precisely so it can be overridden without code
+      changes.
+    * API key requirement — public market-data endpoints have historically
+      been readable without auth, but Kalshi can change this. The operator
+      MUST confirm whether the current market-data endpoints require an API
+      key / bearer token. If they do, an ``api_key`` can be passed and it is
+      sent as a ``Bearer`` ``Authorization`` header; if they don't, leave it
+      unset. Either way this client never sends credentials to a write path.
+    * Endpoint paths / response shapes (``/markets``, ``/markets/{ticker}``,
+      ``/markets/{ticker}/orderbook``) and the cents pricing convention must
+      be re-checked against the live API docs.
+
+Hermetic by construction: all HTTP goes through an injected
+``requests.Session`` so tests never touch the network.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import requests
+
+
+__all__ = [
+    "KalshiAPIError",
+    "KalshiMarketDataClient",
+    "normalize_market",
+]
+
+
+_DEFAULT_BASE_URL = "https://api.elections.kalshi.com/trade-api/v2"
+_DEFAULT_TIMEOUT_S = 10.0
+
+
+class KalshiAPIError(Exception):
+    """Raised when a Kalshi market-data request fails.
+
+    Wraps network errors, non-2xx responses, and malformed payloads with
+    context about which call (and, where relevant, which ticker) failed so
+    callers never see a bare ``requests`` exception leak through.
+    """
+
+
+def _cents_to_prob(cents: Any) -> Optional[float]:
+    """Convert a Kalshi cent price (1-99) to a [0, 1] probability.
+
+    Kalshi quotes Yes/No prices in integer cents where 1c..99c maps to a
+    1%..99% implied probability. Returns ``None`` when the input is missing
+    or non-numeric so normalization never crashes on a partial payload.
+    """
+    if cents is None:
+        return None
+    try:
+        return float(cents) / 100.0
+    except (TypeError, ValueError):
+        return None
+
+
+def normalize_market(raw: Dict[str, Any]) -> Dict[str, Any]:
+    """Project a raw Kalshi market dict onto a common cross-venue schema.
+
+    Returns a dict with the keys:
+        ticker, title, yes_bid, yes_ask, no_bid, no_ask, last_price,
+        volume, close_ts, implied_prob
+
+    All price fields are converted from Kalshi cents (1-99) to [0, 1]
+    probabilities. Missing fields degrade to ``None`` (prices/ts) or ``0``
+    (volume) rather than raising, so a partial payload still normalizes.
+
+    ``implied_prob`` choice:
+        We prefer the Yes mid-price ``(yes_bid + yes_ask) / 2`` because the
+        midpoint is the least-biased single-number estimate of fair value
+        and nets out the bid/ask spread. When only one side is present we
+        fall back to whichever of ``yes_ask`` or ``yes_bid`` exists, and
+        finally to ``last_price``. This mirrors how a maker would mark the
+        book and keeps the number directly comparable to a Polymarket
+        mid-price for arb detection.
+    """
+    if not isinstance(raw, dict):
+        raise KalshiAPIError(
+            f"normalize_market expected a dict, got {type(raw).__name__}"
+        )
+
+    yes_bid = _cents_to_prob(raw.get("yes_bid"))
+    yes_ask = _cents_to_prob(raw.get("yes_ask"))
+    no_bid = _cents_to_prob(raw.get("no_bid"))
+    no_ask = _cents_to_prob(raw.get("no_ask"))
+    last_price = _cents_to_prob(raw.get("last_price"))
+
+    implied_prob = _implied_prob_from_yes(yes_bid, yes_ask, last_price)
+
+    # Volume key varies across Kalshi payloads; accept the common ones.
+    volume = raw.get("volume")
+    if volume is None:
+        volume = raw.get("volume_24h", 0)
+    try:
+        volume = int(volume) if volume is not None else 0
+    except (TypeError, ValueError):
+        volume = 0
+
+    return {
+        "ticker": raw.get("ticker"),
+        "title": raw.get("title"),
+        "yes_bid": yes_bid,
+        "yes_ask": yes_ask,
+        "no_bid": no_bid,
+        "no_ask": no_ask,
+        "last_price": last_price,
+        "volume": volume,
+        "close_ts": raw.get("close_time") or raw.get("close_ts"),
+        "implied_prob": implied_prob,
+    }
+
+
+def _implied_prob_from_yes(
+    yes_bid: Optional[float],
+    yes_ask: Optional[float],
+    last_price: Optional[float],
+) -> Optional[float]:
+    """Derive the implied probability per the documented preference order.
+
+    1. Yes mid-price ``(yes_bid + yes_ask) / 2`` when both sides exist.
+    2. Whichever single Yes quote is present (ask preferred over bid).
+    3. ``last_price`` as a last resort.
+    4. ``None`` when nothing usable is present.
+    """
+    if yes_bid is not None and yes_ask is not None:
+        return (yes_bid + yes_ask) / 2.0
+    if yes_ask is not None:
+        return yes_ask
+    if yes_bid is not None:
+        return yes_bid
+    return last_price
+
+
+class KalshiMarketDataClient:
+    """Read-only client for Kalshi public market-data endpoints.
+
+    All HTTP is issued via an injected (or lazily-created)
+    ``requests.Session`` so the client is fully offline-testable: tests
+    patch ``session.get``.
+
+    Args:
+        base_url:   Override for the trade-api v2 base URL. Defaults to
+                    :data:`_DEFAULT_BASE_URL`. See the module docstring's
+                    live-verification caveat.
+        session:    Injected ``requests.Session`` for tests; a fresh one is
+                    created when omitted.
+        timeout_s:  Per-request timeout in seconds (default 10s).
+        api_key:    Optional bearer token, sent only if the operator has
+                    confirmed market-data reads require auth. Never used for
+                    any write/trade path (there are none here).
+    """
+
+    def __init__(
+        self,
+        base_url: str = _DEFAULT_BASE_URL,
+        session: Optional[requests.Session] = None,
+        timeout_s: float = _DEFAULT_TIMEOUT_S,
+        api_key: Optional[str] = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._session: requests.Session = (
+            session if session is not None else requests.Session()
+        )
+        self._timeout_s = float(timeout_s)
+        self._api_key = api_key
+
+    # ------------------------------------------------------------------
+    # Public read-only API
+    # ------------------------------------------------------------------
+
+    def get_markets(
+        self,
+        limit: int = 100,
+        status: str = "open",
+        cursor: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Fetch a page of markets and normalize each one.
+
+        Returns the list of normalized market dicts (see
+        :func:`normalize_market`). Pagination is exposed via ``cursor`` —
+        the caller passes back the ``cursor`` the API returned to walk
+        subsequent pages.
+        """
+        params: Dict[str, Any] = {"limit": limit, "status": status}
+        if cursor:
+            params["cursor"] = cursor
+
+        payload = self._get("/markets", params=params, context="get_markets")
+        raw_markets = payload.get("markets") if isinstance(payload, dict) else None
+        if not isinstance(raw_markets, list):
+            raw_markets = []
+        return [normalize_market(m) for m in raw_markets if isinstance(m, dict)]
+
+    def get_market(self, ticker: str) -> Dict[str, Any]:
+        """Fetch a single market by ticker and normalize it."""
+        if not ticker:
+            raise KalshiAPIError("get_market called with empty ticker")
+        path = f"/markets/{ticker}"
+        payload = self._get(path, context="get_market", ticker=ticker)
+        raw = payload.get("market") if isinstance(payload, dict) else None
+        if not isinstance(raw, dict):
+            raise KalshiAPIError(
+                f"get_market({ticker!r}): response missing 'market' object"
+            )
+        return normalize_market(raw)
+
+    def get_orderbook(self, ticker: str, depth: int = 10) -> Dict[str, Any]:
+        """Fetch the order book for a ticker.
+
+        Returns the raw ``orderbook`` object from the API (Yes/No price
+        levels). Kept un-normalized: depth/level structure is venue-specific
+        and the arb stage consumes it directly.
+        """
+        if not ticker:
+            raise KalshiAPIError("get_orderbook called with empty ticker")
+        path = f"/markets/{ticker}/orderbook"
+        payload = self._get(
+            path,
+            params={"depth": depth},
+            context="get_orderbook",
+            ticker=ticker,
+        )
+        book = payload.get("orderbook") if isinstance(payload, dict) else None
+        if not isinstance(book, dict):
+            raise KalshiAPIError(
+                f"get_orderbook({ticker!r}): response missing 'orderbook' object"
+            )
+        return book
+
+    # ------------------------------------------------------------------
+    # Internal HTTP
+    # ------------------------------------------------------------------
+
+    def _get(
+        self,
+        path: str,
+        params: Optional[Dict[str, Any]] = None,
+        context: str = "",
+        ticker: Optional[str] = None,
+    ) -> Any:
+        """GET ``path`` and return parsed JSON, wrapping all failures.
+
+        Any network error, non-2xx status, or non-JSON body is re-raised as
+        :class:`KalshiAPIError` with the call context (and ticker, where
+        relevant) and the original exception on ``__cause__``.
+        """
+        url = f"{self._base_url}{path}"
+        where = context or path
+        if ticker:
+            where = f"{where}({ticker!r})"
+
+        headers: Dict[str, str] = {"Accept": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+
+        try:
+            resp = self._session.get(
+                url,
+                params=params,
+                headers=headers,
+                timeout=self._timeout_s,
+            )
+        except requests.RequestException as exc:
+            raise KalshiAPIError(
+                f"Kalshi {where} GET {url} failed: {exc}"
+            ) from exc
+
+        try:
+            resp.raise_for_status()
+        except requests.RequestException as exc:
+            status = getattr(resp, "status_code", "?")
+            raise KalshiAPIError(
+                f"Kalshi {where} GET {url} returned HTTP {status}: {exc}"
+            ) from exc
+
+        try:
+            return resp.json()
+        except (ValueError, requests.RequestException) as exc:
+            raise KalshiAPIError(
+                f"Kalshi {where} GET {url} returned non-JSON body: {exc}"
+            ) from exc

--- a/src/state/pnl_ledger.py
+++ b/src/state/pnl_ledger.py
@@ -1,0 +1,312 @@
+"""Shadow PnL ledger — the single per-trade truth record.
+
+This module is the one auditable place where *every* trade decision and its
+eventual settlement is recorded, regardless of which stack produced it (the
+legacy crypto backtest/paper loop or the prediction-market shadow loop). Before
+this existed there was no auditable paper/backtest result anywhere in the repo.
+
+JSONL event-log model
+---------------------
+The ledger is an **append-only JSONL file**: one JSON object per line, never
+rewritten in place. Each line is an immutable *event*. There are two event
+kinds, both keyed by ``trade_id``:
+
+1. ``"open"`` — emitted by :meth:`PnlLedger.append` when a position is entered.
+   Carries the full :class:`TradeRecord` snapshot at decision/entry time.
+2. ``"settle"`` — emitted by :meth:`PnlLedger.settle` when the position closes.
+   Carries the exit fields (``exit_price``, ``exit_ts_utc``, ``market_outcome``,
+   ``realized_pnl_usd``, ``status``) plus the ``trade_id`` they apply to.
+
+Readers *fold* the event stream into current state: for each ``trade_id`` the
+latest event wins for the fields it carries. The file is therefore an immutable
+audit trail — you can replay it to reconstruct any intermediate state, and a
+settlement never destroys the original entry line. This matches the repo's
+honest-reporting / no-look-ahead ethos: the entry price and decision timestamp
+are written once, at decision time, and can never be silently overwritten.
+
+No look-ahead integrity
+-----------------------
+:meth:`PnlLedger.settle` refuses (raises :class:`ValueError`) any settlement
+whose ``exit_ts_utc`` is strictly before the original entry ``ts_utc``. A trade
+cannot close before it opens; allowing it would let backtests fabricate fills
+from future information, which the Constitution forbids.
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field, fields
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Union
+
+
+DEFAULT_LEDGER_PATH = "runs/pnl_ledger.jsonl"
+
+# Event-kind discriminators written into each JSONL line under "_event".
+EVENT_OPEN = "open"
+EVENT_SETTLE = "settle"
+
+
+@dataclass
+class TradeRecord:
+    """One trade's full lifecycle state, folded from the event log.
+
+    Conventions
+    -----------
+    - ``ts_utc`` is the DECISION/entry time, ISO-8601 (e.g.
+      ``"2026-05-31T14:30:00+00:00"``). It is written once and never changes.
+    - ``size`` is **USD notional** for the position (not unit count). Document
+      it as units only at the call site if a venue ever needs that; the summary
+      math here treats it purely as a label and never derives PnL from it.
+    - ``realized_pnl_usd`` is supplied by the caller at settle time (already net
+      of fees/slippage in the caller's accounting); the ledger does not invent
+      PnL, it only records what the strategy reports.
+    """
+
+    trade_id: str
+    ts_utc: str  # ISO-8601 decision/entry time
+    venue: str  # e.g. 'polymarket' | 'kalshi' | 'coinbase'
+    market_id: str
+    side: str  # e.g. 'YES' | 'NO' | 'long' | 'short'
+    entry_price: float
+    size: float  # USD notional (see class docstring)
+    fees_usd: float
+    slippage_bps: float
+    strategy: str
+    status: str = "open"  # 'open' | 'settled' | 'cancelled'
+    exit_price: Optional[float] = None
+    exit_ts_utc: Optional[str] = None
+    market_outcome: Optional[Union[str, float]] = None
+    realized_pnl_usd: Optional[float] = None
+    notes: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "TradeRecord":
+        known = {f.name for f in fields(cls)}
+        filtered = {k: v for k, v in data.items() if k in known}
+        return cls(**filtered)
+
+
+def _parse_iso8601(value: str) -> datetime:
+    """Parse an ISO-8601 timestamp into a tz-aware UTC ``datetime``.
+
+    Accepts a trailing ``Z`` (treated as ``+00:00``) and naive timestamps
+    (assumed UTC). Raises :class:`ValueError` on anything unparseable so the
+    look-ahead guard fails loudly rather than silently passing.
+    """
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+class PnlLedger:
+    """Append-only JSONL ledger of trade-open and trade-settle events.
+
+    Parameters
+    ----------
+    path:
+        Filesystem path to the JSONL ledger. The parent directory is created
+        on construction if it does not already exist. Defaults to
+        :data:`DEFAULT_LEDGER_PATH`.
+    """
+
+    def __init__(self, path: str = DEFAULT_LEDGER_PATH) -> None:
+        self.path = path
+        parent = os.path.dirname(os.path.abspath(self.path))
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Writes
+    # ------------------------------------------------------------------
+    def append(self, record: TradeRecord) -> None:
+        """Append an ``open`` event for ``record`` (one JSON line)."""
+        payload = record.to_dict()
+        payload["_event"] = EVENT_OPEN
+        self._write_line(payload)
+
+    def settle(
+        self,
+        trade_id: str,
+        exit_price: float,
+        exit_ts_utc: str,
+        market_outcome: Optional[Union[str, float]] = None,
+        realized_pnl_usd: Optional[float] = None,
+    ) -> TradeRecord:
+        """Append a ``settle`` event for ``trade_id`` and return the folded record.
+
+        Raises
+        ------
+        KeyError
+            If ``trade_id`` has no prior ``open`` event in the ledger.
+        ValueError
+            If ``exit_ts_utc`` is strictly before the record's entry ``ts_utc``
+            (the no-look-ahead guard), or if either timestamp is unparseable.
+        """
+        state = self._fold()
+        record = state.get(trade_id)
+        if record is None:
+            raise KeyError(f"cannot settle unknown trade_id: {trade_id!r}")
+
+        entry_dt = _parse_iso8601(record.ts_utc)
+        exit_dt = _parse_iso8601(exit_ts_utc)
+        if exit_dt < entry_dt:
+            raise ValueError(
+                "look-ahead guard: exit_ts_utc "
+                f"({exit_ts_utc}) is before entry ts_utc ({record.ts_utc}) "
+                f"for trade_id {trade_id!r}"
+            )
+
+        settle_payload: Dict[str, Any] = {
+            "_event": EVENT_SETTLE,
+            "trade_id": trade_id,
+            "status": "settled",
+            "exit_price": float(exit_price),
+            "exit_ts_utc": exit_ts_utc,
+            "market_outcome": market_outcome,
+            "realized_pnl_usd": (
+                None if realized_pnl_usd is None else float(realized_pnl_usd)
+            ),
+        }
+        self._write_line(settle_payload)
+
+        # Return the up-to-date folded record so callers don't re-read.
+        record.status = "settled"
+        record.exit_price = float(exit_price)
+        record.exit_ts_utc = exit_ts_utc
+        record.market_outcome = market_outcome
+        record.realized_pnl_usd = (
+            None if realized_pnl_usd is None else float(realized_pnl_usd)
+        )
+        return record
+
+    def _write_line(self, payload: Dict[str, Any]) -> None:
+        """Append a single JSON object as one line, flushing to disk.
+
+        Uses a single ``write()`` of a newline-terminated string under append
+        mode so concurrent appenders never interleave partial lines, and
+        ``flush`` + ``fsync`` so a crash right after the call still leaves a
+        complete, parseable ledger.
+        """
+        line = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+        with open(self.path, "a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+    def _fold(self) -> "Dict[str, TradeRecord]":
+        """Replay the event log into current per-``trade_id`` state.
+
+        Missing or empty file yields an empty mapping. Lines that are blank or
+        unparseable JSON are skipped (the ledger stays readable even if a write
+        was truncated by a crash mid-line).
+        """
+        state: Dict[str, TradeRecord] = {}
+        if not os.path.exists(self.path):
+            return state
+        with open(self.path, "r", encoding="utf-8") as handle:
+            for raw in handle:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    event = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(event, dict):
+                    continue
+                kind = event.get("_event")
+                trade_id = event.get("trade_id")
+                if not trade_id:
+                    continue
+                if kind == EVENT_OPEN:
+                    state[trade_id] = TradeRecord.from_dict(event)
+                elif kind == EVENT_SETTLE:
+                    record = state.get(trade_id)
+                    if record is None:
+                        # Settlement with no prior open — keep the audit trail
+                        # honest by ignoring it rather than fabricating an entry.
+                        continue
+                    if "status" in event:
+                        record.status = event["status"]
+                    if "exit_price" in event:
+                        record.exit_price = event["exit_price"]
+                    if "exit_ts_utc" in event:
+                        record.exit_ts_utc = event["exit_ts_utc"]
+                    if "market_outcome" in event:
+                        record.market_outcome = event["market_outcome"]
+                    if "realized_pnl_usd" in event:
+                        record.realized_pnl_usd = event["realized_pnl_usd"]
+        return state
+
+    def all_records(self) -> List[TradeRecord]:
+        """Return every folded record (open + settled + cancelled)."""
+        return list(self._fold().values())
+
+    def open_positions(self) -> List[TradeRecord]:
+        """Return records still in ``open`` status."""
+        return [r for r in self._fold().values() if r.status == "open"]
+
+    def settled(self) -> List[TradeRecord]:
+        """Return records in ``settled`` status."""
+        return [r for r in self._fold().values() if r.status == "settled"]
+
+    def by_strategy(self, name: str) -> List[TradeRecord]:
+        """Return all records (any status) for a given strategy name."""
+        return [r for r in self._fold().values() if r.strategy == name]
+
+    def summary(self) -> Dict[str, Any]:
+        """Aggregate the ledger into a headline dict.
+
+        Returns keys: ``total_realized_pnl_usd``, ``n_trades``, ``n_settled``,
+        ``n_open``, ``win_rate`` (settled wins / settled, 0.0 if none settled),
+        ``total_fees_usd``. A missing/empty ledger returns all-zero values.
+        """
+        records = list(self._fold().values())
+        n_trades = len(records)
+        settled = [r for r in records if r.status == "settled"]
+        n_settled = len(settled)
+        n_open = sum(1 for r in records if r.status == "open")
+
+        total_realized = sum(
+            r.realized_pnl_usd
+            for r in settled
+            if r.realized_pnl_usd is not None
+        )
+        total_fees = sum(
+            r.fees_usd for r in records if r.fees_usd is not None
+        )
+        wins = sum(
+            1
+            for r in settled
+            if r.realized_pnl_usd is not None and r.realized_pnl_usd > 0
+        )
+        win_rate = (wins / n_settled) if n_settled else 0.0
+
+        return {
+            "total_realized_pnl_usd": float(total_realized),
+            "n_trades": n_trades,
+            "n_settled": n_settled,
+            "n_open": n_open,
+            "win_rate": win_rate,
+            "total_fees_usd": float(total_fees),
+        }
+
+
+__all__ = [
+    "DEFAULT_LEDGER_PATH",
+    "EVENT_OPEN",
+    "EVENT_SETTLE",
+    "PnlLedger",
+    "TradeRecord",
+]

--- a/tests/prediction_market_scanner/test_arb_detector.py
+++ b/tests/prediction_market_scanner/test_arb_detector.py
@@ -1,0 +1,206 @@
+"""Unit tests for the model-free arbitrage detector (``arb_detector``).
+
+These pin down the intra-market arbitrage accounting identity (buy YES + NO,
+guaranteed $1 payout), the honest cost netting (settlement fee on the $1 payout +
+gas), the scan/sort/shadow-ledger closed loop, and the directional-EV helper.
+
+Run:
+    env PYTHONPATH=src ./.venv/bin/python -m unittest \
+        tests.prediction_market_scanner.test_arb_detector -v
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+from arb_detector import (
+    intramarket_arb,
+    market_row_to_arb_input,
+    net_directional_edge,
+    scan_intramarket_arbs,
+)
+from state.pnl_ledger import PnlLedger
+
+
+class IntramarketArbTests(unittest.TestCase):
+    def test_arb_returned_with_thin_fee_correct_math(self) -> None:
+        # yes_ask + no_ask = 0.97 < 1 -> gross edge 0.03; zero fee/gas keeps it.
+        arb = intramarket_arb(0.48, 0.49, settlement_fee_bps=0.0, gas_usd=0.0)
+        self.assertIsNotNone(arb)
+        assert arb is not None  # for type-checkers
+        self.assertAlmostEqual(arb["cost_basis"], 0.97)
+        self.assertAlmostEqual(arb["gross_edge"], 0.03)
+        self.assertAlmostEqual(arb["net_edge_per_pair"], 0.03)
+        self.assertAlmostEqual(arb["settlement_fee_usd"], 0.0)
+        self.assertAlmostEqual(arb["gas_usd"], 0.0)
+        # net_edge_pct = net / cost_basis = 0.03 / 0.97.
+        self.assertAlmostEqual(arb["net_edge_pct"], 0.03 / 0.97)
+        # est_profit_usd is 0 when size is not supplied.
+        self.assertEqual(arb["est_profit_usd"], 0.0)
+        # Legs carry both sides at their ask prices.
+        self.assertEqual(
+            arb["legs"],
+            [{"side": "YES", "price": 0.48}, {"side": "NO", "price": 0.49}],
+        )
+
+    def test_default_fee_haircut_still_arb(self) -> None:
+        # Same 0.03 gross, but with the default 200bps fee ($0.02) netted out.
+        arb = intramarket_arb(0.48, 0.49)  # default settlement_fee_bps=200
+        self.assertIsNotNone(arb)
+        assert arb is not None
+        self.assertAlmostEqual(arb["settlement_fee_usd"], 0.02)
+        self.assertAlmostEqual(arb["net_edge_per_pair"], 0.03 - 0.02)
+        self.assertAlmostEqual(arb["net_edge_pct"], (0.03 - 0.02) / 0.97)
+
+    def test_no_arb_when_sum_at_or_above_one(self) -> None:
+        # yes_ask + no_ask = 1.05 >= 1 -> no gross edge at all.
+        self.assertIsNone(intramarket_arb(0.55, 0.50, settlement_fee_bps=0.0))
+        # Exactly 1.00 is also not an arb (gross_edge == 0, not > 0).
+        self.assertIsNone(intramarket_arb(0.50, 0.50, settlement_fee_bps=0.0))
+
+    def test_gross_edge_eaten_by_fee_and_gas_returns_none(self) -> None:
+        # cost_basis 0.99 -> gross 0.01. 200bps fee = $0.02 alone exceeds it.
+        self.assertIsNone(intramarket_arb(0.49, 0.50, settlement_fee_bps=200.0))
+        # Even with a smaller fee, gas can eat the remaining edge.
+        # cost 0.98 -> gross 0.02; 50bps fee = $0.005, gas $0.02 -> net -0.005.
+        self.assertIsNone(
+            intramarket_arb(0.49, 0.49, settlement_fee_bps=50.0, gas_usd=0.02)
+        )
+
+    def test_size_usd_produces_correct_est_profit(self) -> None:
+        # cost 0.80 -> gross 0.20, zero fee -> net 0.20 per pair.
+        # size_usd 500 = 500 pairs (each pays $1) -> est profit 0.20 * 500 = 100.
+        arb = intramarket_arb(0.40, 0.40, settlement_fee_bps=0.0, size_usd=500.0)
+        self.assertIsNotNone(arb)
+        assert arb is not None
+        self.assertAlmostEqual(arb["net_edge_per_pair"], 0.20)
+        self.assertAlmostEqual(arb["est_profit_usd"], 100.0)
+
+    def test_input_validation_rejects_out_of_range_prices(self) -> None:
+        for bad in (0.0, -0.1, 1.0, 1.5):
+            with self.assertRaises(ValueError):
+                intramarket_arb(bad, 0.5)
+            with self.assertRaises(ValueError):
+                intramarket_arb(0.5, bad)
+
+
+class ScanIntramarketArbsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self._tmp.name, "arb_ledger.jsonl")
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_sorts_by_net_edge_pct_and_logs_shadow_records(self) -> None:
+        ledger = PnlLedger(self.path)
+        markets = [
+            # net_pct ~ (0.03 - 0.02)/0.97 = 0.01031 -> below 0.005? no, above.
+            {"market_id": "small-edge", "yes_ask": 0.48, "no_ask": 0.49},
+            # net_pct ~ (0.20 - 0.02)/0.80 = 0.225 -> big edge.
+            {"market_id": "big-edge", "yes_ask": 0.40, "no_ask": 0.40},
+            # No arb: sum >= 1, must be skipped (no record, not in results).
+            {"market_id": "no-edge", "yes_ask": 0.55, "no_ask": 0.50},
+            # Missing no_ask -> skipped silently.
+            {"market_id": "incomplete", "yes_ask": 0.40},
+        ]
+
+        results = scan_intramarket_arbs(markets, ledger=ledger, min_net_edge_pct=0.005)
+
+        # Two real arbs, sorted by net_edge_pct descending.
+        self.assertEqual([r["market_id"] for r in results], ["big-edge", "small-edge"])
+        self.assertGreater(results[0]["net_edge_pct"], results[1]["net_edge_pct"])
+        for r in results:
+            self.assertEqual(r["strategy"], "intramarket_arb")
+
+        # Exactly two SHADOW open records were logged, with the expected fields.
+        open_positions = ledger.open_positions()
+        self.assertEqual(len(open_positions), 2)
+        by_market = {r.market_id: r for r in open_positions}
+        self.assertEqual(set(by_market), {"big-edge", "small-edge"})
+        for rec in open_positions:
+            self.assertEqual(rec.status, "open")
+            self.assertEqual(rec.venue, "polymarket")
+            self.assertEqual(rec.strategy, "intramarket_arb")
+            self.assertEqual(rec.side, "YES+NO")
+            self.assertIn("SHADOW", rec.notes)
+            self.assertIn("NO order placed", rec.notes)
+        # entry_price is the cost basis of the pair.
+        self.assertAlmostEqual(by_market["big-edge"].entry_price, 0.80)
+        self.assertAlmostEqual(by_market["small-edge"].entry_price, 0.97)
+        # fees_usd is the settlement fee on $1 payout (default 200bps = $0.02).
+        self.assertAlmostEqual(by_market["big-edge"].fees_usd, 0.02)
+
+    def test_min_net_edge_pct_filters_out_thin_arbs(self) -> None:
+        # gross 0.03, 200bps fee -> net 0.01, net_pct ~ 0.0103.
+        # A 0.05 (5%) threshold filters it out; no record logged.
+        ledger = PnlLedger(self.path)
+        markets = [{"market_id": "thin", "yes_ask": 0.48, "no_ask": 0.49}]
+        results = scan_intramarket_arbs(markets, ledger=ledger, min_net_edge_pct=0.05)
+        self.assertEqual(results, [])
+        self.assertEqual(ledger.open_positions(), [])
+
+    def test_size_usd_propagates_to_records_and_profit(self) -> None:
+        ledger = PnlLedger(self.path)
+        markets = [{"id": "sized", "yes_ask": 0.40, "no_ask": 0.40}]
+        results = scan_intramarket_arbs(
+            markets, ledger=ledger, min_net_edge_pct=0.005, size_usd=500.0
+        )
+        self.assertEqual(len(results), 1)
+        self.assertAlmostEqual(results[0]["est_profit_usd"], 100.0 - 500.0 * 0.02)
+        rec = ledger.open_positions()[0]
+        self.assertEqual(rec.market_id, "sized")  # tolerant of 'id' key
+        self.assertAlmostEqual(rec.size, 500.0)
+
+    def test_tolerates_field_name_variants(self) -> None:
+        # camelCase / alternate keys must still be read.
+        markets = [{"ticker": "ALT", "yesAsk": 0.40, "noAsk": 0.40}]
+        results = scan_intramarket_arbs(markets, min_net_edge_pct=0.005)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["market_id"], "ALT")
+
+
+class NetDirectionalEdgeTests(unittest.TestCase):
+    def test_positive_pre_fee_edge(self) -> None:
+        # fair 0.60 vs ask 0.50 with zero fee: EV = 0.60 - 0.50 = +0.10.
+        ev = net_directional_edge(0.60, 0.50, settlement_fee_bps=0.0)
+        self.assertAlmostEqual(ev, 0.10)
+
+    def test_fee_haircut_reduces_edge(self) -> None:
+        # 200bps fee on the $1 payout, weighted by win prob 0.60:
+        # EV = 0.60 * (1 - 0.02) - 0.50 = 0.588 - 0.50 = 0.088 < 0.10.
+        ev = net_directional_edge(0.60, 0.50, settlement_fee_bps=200.0)
+        self.assertAlmostEqual(ev, 0.088)
+        self.assertLess(ev, 0.10)
+
+    def test_negative_edge_when_ask_above_fair(self) -> None:
+        # Buying at 0.70 when fair is only 0.55 is a losing bet pre-fee.
+        ev = net_directional_edge(0.55, 0.70, settlement_fee_bps=0.0)
+        self.assertAlmostEqual(ev, 0.55 - 0.70)
+        self.assertLess(ev, 0.0)
+
+    def test_rejects_bad_inputs(self) -> None:
+        with self.assertRaises(ValueError):
+            net_directional_edge(1.2, 0.5)  # prob out of [0,1]
+        with self.assertRaises(ValueError):
+            net_directional_edge(0.5, 1.0)  # ask not in (0,1)
+
+
+class MarketRowMappingTests(unittest.TestCase):
+    def test_returns_none_without_no_ask(self) -> None:
+        # A bare scanner row (implied_prob only) cannot prove an arb on its own.
+        row = {"market_id": "m1", "implied_prob": 0.42, "spread": 0.03}
+        self.assertIsNone(market_row_to_arb_input(row))
+
+    def test_maps_with_explicit_no_ask(self) -> None:
+        row = {"market_id": "m2", "implied_prob": 0.42}
+        mapped = market_row_to_arb_input(row, no_ask=0.50)
+        self.assertEqual(mapped["market_id"], "m2")
+        self.assertAlmostEqual(mapped["yes_ask"], 0.42)
+        self.assertAlmostEqual(mapped["no_ask"], 0.50)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/prediction_market_scanner/test_fee_honesty_kill.py
+++ b/tests/prediction_market_scanner/test_fee_honesty_kill.py
@@ -1,0 +1,182 @@
+"""Deterministic, env-independent proof that the crypto 1m directional stack
+is unprofitable by ARITHMETIC, not tuning.
+
+The model targets a +10-20 bps move. The repo's own Coinbase adapter charges a
+real fee of 60 bps taker / 40 bps maker per side (see
+``src/exchanges/adapters/coinbase_tradeable.py`` ->
+``FeeModel(maker=0.0040, taker=0.0060)``). A taker round-trip therefore costs
+~120 bps. 20 bps gross < 120 bps cost => every "winning" trade still loses money.
+
+Historically the simulator defaulted to ``fee_pct=0.0008`` (~16 bps round-trip)
+and ``src/backtest.py`` hardcoded an even cheaper ``0.00075``, while leaving the
+maker path unwired (``_maker_fee_pct`` fell back to ``fee_pct``). That ~7.5x cost
+understatement made every backtest fictional. This test pins the honest behavior:
+
+  1. A trade that PERFECTLY hits a +20 bps target, run through the simulator
+     configured with the real Coinbase taker fee, nets NEGATIVE PnL.
+  2. The effective round-trip cost under Coinbase-taker config is ~120 bps,
+     versus ~16 bps under the old cheap default.
+
+Run:
+  env PYTHONPATH=src ./.venv/bin/python -m unittest \
+      tests.prediction_market_scanner.test_fee_honesty_kill -v
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+
+# ``trading/simulator.py`` imports flat (``from utils import ...``) like the rest
+# of the legacy stack. With ``PYTHONPATH=src`` ``utils`` resolves; we just have to
+# make the ``trading`` package importable too.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_TRADING_DIR = os.path.join(_REPO_ROOT, "trading")
+for _p in (_TRADING_DIR, os.path.join(_REPO_ROOT, "src"), _REPO_ROOT):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from simulator import (  # noqa: E402
+    Bar,
+    COINBASE_MAKER_FEE_PCT,
+    COINBASE_TAKER_FEE_PCT,
+    PortfolioSimulator,
+    SimulationConfig,
+)
+
+
+ENTRY_PRICE = 100.0
+TARGET_BPS = 0.0020  # +20 bps — the rosy end of the model's 10-20 bps target
+START_CAPITAL = 10_000.0
+
+
+def _flat_taker_config(**overrides) -> SimulationConfig:
+    """A deterministic, depth/slippage-free config with a pure taker round-trip.
+
+    Depth and slippage are disabled so the entry fills at the bar open and the
+    exit fills at the requested price — isolating the FEE arithmetic. Stops are
+    set wide so neither TP nor SL fires; we exit via ``finalize`` (a taker
+    ``close_end`` fill) at exactly the +20 bps target.
+    """
+    base = dict(
+        start_capital=START_CAPITAL,
+        use_market_depth=False,
+        slippage_pct=0.0,
+        post_only_entries=False,   # taker market entry
+        use_atr_stops=False,
+        tp_pct=0.10,               # wide — does not trigger
+        sl_pct=0.10,               # wide — does not trigger
+        use_regime_filter=False,
+        min_atr_pct=0.0,
+        allow_shorts=True,
+        cooldown=0,
+    )
+    base.update(overrides)
+    return base
+
+
+def _run_perfect_winner(cfg: SimulationConfig) -> PortfolioSimulator:
+    """Enter long (taker), then close at exactly +20 bps (taker close_end)."""
+    sim = PortfolioSimulator(cfg)
+    target_price = ENTRY_PRICE * (1.0 + TARGET_BPS)
+
+    # Bar 0: emit the long signal (becomes pending), price flat at ENTRY_PRICE.
+    sim.step(Bar(open=ENTRY_PRICE, high=ENTRY_PRICE, low=ENTRY_PRICE, close=ENTRY_PRICE), signal=1)
+    # Bar 1: pending long executes at this bar's open (== ENTRY_PRICE).
+    sim.step(Bar(open=ENTRY_PRICE, high=ENTRY_PRICE, low=ENTRY_PRICE, close=ENTRY_PRICE), signal=0)
+    # Close the position at exactly the +20 bps target (taker close_end exit).
+    sim.finalize(target_price)
+    return sim
+
+
+def _round_trip_cost_bps(cfg: SimulationConfig) -> float:
+    """Open + close a position with ZERO gross move; return total fees in bps."""
+    sim = PortfolioSimulator(cfg)
+    sim.step(Bar(open=ENTRY_PRICE, high=ENTRY_PRICE, low=ENTRY_PRICE, close=ENTRY_PRICE), signal=1)
+    sim.step(Bar(open=ENTRY_PRICE, high=ENTRY_PRICE, low=ENTRY_PRICE, close=ENTRY_PRICE), signal=0)
+    sim.finalize(ENTRY_PRICE)  # flat close: PnL is fees only
+    total_fee = cfg.start_capital - sim.last_equity
+    return total_fee / cfg.start_capital * 1e4
+
+
+class FeeHonestyKillTest(unittest.TestCase):
+    def test_coinbase_default_constants_match_live_adapter(self):
+        # These must mirror src/exchanges/adapters/coinbase_tradeable.py.
+        self.assertAlmostEqual(COINBASE_TAKER_FEE_PCT, 0.0060, places=6)
+        self.assertAlmostEqual(COINBASE_MAKER_FEE_PCT, 0.0040, places=6)
+
+    def test_from_coinbase_fees_wires_both_taker_and_maker(self):
+        cfg = SimulationConfig.from_coinbase_fees()
+        # ``fee_pct`` is the taker rate; ``maker_fee_pct`` is set explicitly so the
+        # maker path is no longer fictional (it used to fall back to ``fee_pct``).
+        self.assertAlmostEqual(cfg.fee_pct, 0.0060, places=6)
+        self.assertIsNotNone(cfg.maker_fee_pct)
+        self.assertAlmostEqual(cfg.maker_fee_pct, 0.0040, places=6)
+
+    def test_from_fee_model_accepts_live_fee_model(self):
+        # Duck-typed: any object exposing .maker/.taker (e.g. protocols.FeeModel).
+        from protocols import FeeModel
+
+        cfg = SimulationConfig.from_fee_model(FeeModel(maker=0.0040, taker=0.0060))
+        self.assertAlmostEqual(cfg.fee_pct, 0.0060, places=6)
+        self.assertAlmostEqual(cfg.maker_fee_pct, 0.0040, places=6)
+
+    def test_perfect_20bps_winner_nets_negative_under_real_coinbase_fees(self):
+        """THE KILL: a trade that perfectly hits +20 bps still LOSES money."""
+        cfg = SimulationConfig.from_coinbase_fees(**_flat_taker_config())
+        sim = _run_perfect_winner(cfg)
+
+        net_pnl = sim.last_equity - START_CAPITAL
+        self.assertLess(
+            net_pnl,
+            0.0,
+            msg=(
+                "A perfect +20 bps winner must net NEGATIVE under real Coinbase "
+                f"taker fees (got net PnL={net_pnl:.4f}). 20 bps gross cannot "
+                "clear ~120 bps round-trip cost."
+            ),
+        )
+
+        # Exact arithmetic: +20 bps gross on 10k notional = +$20; two taker fees
+        # of 60 bps on 10k = -$60 each => net = 20 - 120 = -$100.
+        self.assertAlmostEqual(net_pnl, -100.0, places=2)
+
+        # Both legs filled as taker (no fictional maker discount).
+        self.assertEqual(sim.maker_fills, 0)
+        self.assertEqual(sim.taker_fills, 2)
+
+    def test_effective_round_trip_cost_is_about_120bps_under_coinbase(self):
+        cfg = SimulationConfig.from_coinbase_fees(**_flat_taker_config())
+        cost_bps = _round_trip_cost_bps(cfg)
+        # 2 x 60 bps taker = ~120 bps. Allow a hair of tolerance.
+        self.assertGreater(cost_bps, 115.0)
+        self.assertLess(cost_bps, 125.0)
+        self.assertAlmostEqual(cost_bps, 120.0, places=2)
+
+    def test_old_cheap_default_understated_cost_at_about_16bps(self):
+        # Evidence of the bug: the legacy ~8 bps default round-trips at ~16 bps,
+        # which is why fictional backtests "passed". This is what we replaced.
+        legacy_cfg = SimulationConfig(**_flat_taker_config())
+        cost_bps = _round_trip_cost_bps(legacy_cfg)
+        self.assertAlmostEqual(cost_bps, 16.0, places=2)
+        # And it is ~7.5x cheaper than the honest Coinbase cost.
+        coinbase_cfg = SimulationConfig.from_coinbase_fees(**_flat_taker_config())
+        honest_bps = _round_trip_cost_bps(coinbase_cfg)
+        self.assertAlmostEqual(honest_bps / cost_bps, 7.5, places=2)
+
+    def test_under_old_cheap_fees_the_same_winner_is_profitable(self):
+        # Control: the EXACT same +20 bps winner is profitable under the old cheap
+        # fees. This proves the kill is driven by the fee correction, not by the
+        # test scenario being rigged to lose.
+        legacy_cfg = SimulationConfig(**_flat_taker_config())
+        sim = _run_perfect_winner(legacy_cfg)
+        net_pnl = sim.last_equity - START_CAPITAL
+        # +20 bps gross (=$20) minus ~16 bps fees (=$16) => +$4 net.
+        self.assertGreater(net_pnl, 0.0)
+        self.assertAlmostEqual(net_pnl, 4.0, places=2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/prediction_market_scanner/test_kalshi_market_data.py
+++ b/tests/prediction_market_scanner/test_kalshi_market_data.py
@@ -1,0 +1,356 @@
+"""Tests for src/exchanges/kalshi_market_data.py.
+
+Hermetic — never makes a real HTTPS call. We patch ``session.get`` to return
+a stub response whose ``.json()`` yields canned Kalshi-shaped payloads, and
+assert on parsing, cents->probability conversion, error wrapping, and
+missing-field tolerance.
+"""
+
+from __future__ import annotations
+
+import unittest
+from typing import Any, Dict, Optional
+from unittest import mock
+
+import requests
+
+from exchanges.kalshi_market_data import (
+    KalshiAPIError,
+    KalshiMarketDataClient,
+    normalize_market,
+)
+
+
+# ---------------------------------------------------------------------------
+# Stub HTTP scaffolding
+# ---------------------------------------------------------------------------
+
+
+class _StubResponse:
+    """Minimal ``requests.Response`` shaped stub."""
+
+    def __init__(
+        self,
+        json_data: Any = None,
+        status_code: int = 200,
+        raise_on_json: Optional[Exception] = None,
+    ) -> None:
+        self._json_data = json_data
+        self.status_code = status_code
+        self._raise_on_json = raise_on_json
+
+    def raise_for_status(self) -> None:
+        if not (200 <= int(self.status_code) < 300):
+            raise requests.HTTPError(f"HTTP {self.status_code}")
+
+    def json(self) -> Any:
+        if self._raise_on_json is not None:
+            raise self._raise_on_json
+        return self._json_data
+
+
+# ---------------------------------------------------------------------------
+# Sample payloads (realistic Kalshi shapes; prices in cents 1-99)
+# ---------------------------------------------------------------------------
+
+
+def _markets_payload() -> Dict[str, Any]:
+    return {
+        "cursor": "next_page_token",
+        "markets": [
+            {
+                "ticker": "PRESWIN-24-DEM",
+                "title": "Will the Democratic candidate win?",
+                "yes_bid": 58,
+                "yes_ask": 62,
+                "no_bid": 38,
+                "no_ask": 42,
+                "last_price": 60,
+                "volume": 12345,
+                "close_time": "2024-11-05T23:59:59Z",
+                "status": "open",
+            },
+            {
+                "ticker": "RATE-HIKE-Q1",
+                "title": "Will the Fed hike rates in Q1?",
+                "yes_bid": 10,
+                "yes_ask": 14,
+                "no_bid": 86,
+                "no_ask": 90,
+                "last_price": 12,
+                "volume": 678,
+                "close_time": "2025-03-31T23:59:59Z",
+                "status": "open",
+            },
+        ],
+    }
+
+
+def _single_market_payload() -> Dict[str, Any]:
+    return {
+        "market": {
+            "ticker": "PRESWIN-24-DEM",
+            "title": "Will the Democratic candidate win?",
+            "yes_bid": 58,
+            "yes_ask": 62,
+            "no_bid": 38,
+            "no_ask": 42,
+            "last_price": 60,
+            "volume": 12345,
+            "close_time": "2024-11-05T23:59:59Z",
+            "status": "open",
+        }
+    }
+
+
+def _orderbook_payload() -> Dict[str, Any]:
+    return {
+        "orderbook": {
+            # Kalshi books: [price_in_cents, quantity] levels per side.
+            "yes": [[58, 1000], [57, 2500], [56, 4000]],
+            "no": [[42, 1200], [43, 1800], [44, 3000]],
+        }
+    }
+
+
+def _make_client(get_mock: mock.Mock) -> KalshiMarketDataClient:
+    session = mock.Mock(spec=requests.Session)
+    session.get = get_mock
+    return KalshiMarketDataClient(session=session)
+
+
+# ---------------------------------------------------------------------------
+# get_markets: parse + normalize
+# ---------------------------------------------------------------------------
+
+
+class GetMarketsTest(unittest.TestCase):
+    def test_get_markets_parses_and_normalizes(self) -> None:
+        get_mock = mock.Mock(return_value=_StubResponse(_markets_payload()))
+        client = _make_client(get_mock)
+
+        markets = client.get_markets(limit=50, status="open")
+
+        self.assertEqual(len(markets), 2)
+        first = markets[0]
+        # Common schema keys present.
+        self.assertEqual(
+            set(first.keys()),
+            {
+                "ticker",
+                "title",
+                "yes_bid",
+                "yes_ask",
+                "no_bid",
+                "no_ask",
+                "last_price",
+                "volume",
+                "close_ts",
+                "implied_prob",
+            },
+        )
+        self.assertEqual(first["ticker"], "PRESWIN-24-DEM")
+        self.assertEqual(first["close_ts"], "2024-11-05T23:59:59Z")
+        self.assertEqual(first["volume"], 12345)
+
+    def test_get_markets_passes_query_params(self) -> None:
+        get_mock = mock.Mock(return_value=_StubResponse(_markets_payload()))
+        client = _make_client(get_mock)
+
+        client.get_markets(limit=25, status="open", cursor="abc123")
+
+        _, kwargs = get_mock.call_args
+        self.assertEqual(kwargs["params"]["limit"], 25)
+        self.assertEqual(kwargs["params"]["status"], "open")
+        self.assertEqual(kwargs["params"]["cursor"], "abc123")
+        self.assertEqual(kwargs["timeout"], 10.0)
+
+    def test_get_markets_handles_empty_payload(self) -> None:
+        get_mock = mock.Mock(return_value=_StubResponse({}))
+        client = _make_client(get_mock)
+        self.assertEqual(client.get_markets(), [])
+
+
+# ---------------------------------------------------------------------------
+# cents -> probability conversion
+# ---------------------------------------------------------------------------
+
+
+class CentsToProbabilityTest(unittest.TestCase):
+    def test_yes_ask_60c_to_060(self) -> None:
+        raw = {"ticker": "X", "yes_ask": 60}
+        norm = normalize_market(raw)
+        self.assertAlmostEqual(norm["yes_ask"], 0.60)
+
+    def test_all_price_fields_scaled_to_unit_interval(self) -> None:
+        raw = {
+            "ticker": "X",
+            "yes_bid": 58,
+            "yes_ask": 62,
+            "no_bid": 38,
+            "no_ask": 42,
+            "last_price": 60,
+        }
+        norm = normalize_market(raw)
+        self.assertAlmostEqual(norm["yes_bid"], 0.58)
+        self.assertAlmostEqual(norm["yes_ask"], 0.62)
+        self.assertAlmostEqual(norm["no_bid"], 0.38)
+        self.assertAlmostEqual(norm["no_ask"], 0.42)
+        self.assertAlmostEqual(norm["last_price"], 0.60)
+
+    def test_implied_prob_is_yes_midpoint(self) -> None:
+        # mid of 58c/62c -> (0.58 + 0.62) / 2 = 0.60
+        raw = {"ticker": "X", "yes_bid": 58, "yes_ask": 62, "last_price": 99}
+        norm = normalize_market(raw)
+        self.assertAlmostEqual(norm["implied_prob"], 0.60)
+
+    def test_implied_prob_falls_back_to_ask_then_bid_then_last(self) -> None:
+        ask_only = normalize_market({"ticker": "X", "yes_ask": 70})
+        self.assertAlmostEqual(ask_only["implied_prob"], 0.70)
+
+        bid_only = normalize_market({"ticker": "X", "yes_bid": 30})
+        self.assertAlmostEqual(bid_only["implied_prob"], 0.30)
+
+        last_only = normalize_market({"ticker": "X", "last_price": 45})
+        self.assertAlmostEqual(last_only["implied_prob"], 0.45)
+
+
+# ---------------------------------------------------------------------------
+# Error handling: network / HTTP errors raise KalshiAPIError
+# ---------------------------------------------------------------------------
+
+
+class ErrorHandlingTest(unittest.TestCase):
+    def test_network_error_raises_kalshi_api_error(self) -> None:
+        get_mock = mock.Mock(
+            side_effect=requests.ConnectionError("connection refused")
+        )
+        client = _make_client(get_mock)
+        with self.assertRaises(KalshiAPIError) as ctx:
+            client.get_markets()
+        # Context preserved, original on __cause__, not a bare requests error.
+        self.assertIn("get_markets", str(ctx.exception))
+        self.assertIsInstance(ctx.exception.__cause__, requests.ConnectionError)
+
+    def test_timeout_raises_kalshi_api_error(self) -> None:
+        get_mock = mock.Mock(side_effect=requests.Timeout("timed out"))
+        client = _make_client(get_mock)
+        with self.assertRaises(KalshiAPIError):
+            client.get_market("PRESWIN-24-DEM")
+
+    def test_http_500_raises_kalshi_api_error_with_ticker_context(self) -> None:
+        get_mock = mock.Mock(return_value=_StubResponse({}, status_code=500))
+        client = _make_client(get_mock)
+        with self.assertRaises(KalshiAPIError) as ctx:
+            client.get_orderbook("RATE-HIKE-Q1")
+        msg = str(ctx.exception)
+        self.assertIn("get_orderbook", msg)
+        self.assertIn("RATE-HIKE-Q1", msg)
+        self.assertIsInstance(ctx.exception.__cause__, requests.HTTPError)
+
+    def test_non_json_body_raises_kalshi_api_error(self) -> None:
+        get_mock = mock.Mock(
+            return_value=_StubResponse(raise_on_json=ValueError("no json"))
+        )
+        client = _make_client(get_mock)
+        with self.assertRaises(KalshiAPIError):
+            client.get_markets()
+
+    def test_empty_ticker_rejected(self) -> None:
+        get_mock = mock.Mock(return_value=_StubResponse(_single_market_payload()))
+        client = _make_client(get_mock)
+        with self.assertRaises(KalshiAPIError):
+            client.get_market("")
+        with self.assertRaises(KalshiAPIError):
+            client.get_orderbook("")
+
+
+# ---------------------------------------------------------------------------
+# get_market / get_orderbook happy paths
+# ---------------------------------------------------------------------------
+
+
+class GetMarketAndOrderbookTest(unittest.TestCase):
+    def test_get_market_normalizes_single(self) -> None:
+        get_mock = mock.Mock(return_value=_StubResponse(_single_market_payload()))
+        client = _make_client(get_mock)
+
+        market = client.get_market("PRESWIN-24-DEM")
+        self.assertEqual(market["ticker"], "PRESWIN-24-DEM")
+        self.assertAlmostEqual(market["yes_ask"], 0.62)
+        self.assertAlmostEqual(market["implied_prob"], 0.60)
+
+        # URL path includes the ticker.
+        args, _ = get_mock.call_args
+        self.assertIn("/markets/PRESWIN-24-DEM", args[0])
+
+    def test_get_market_missing_market_object_raises(self) -> None:
+        get_mock = mock.Mock(return_value=_StubResponse({"unexpected": True}))
+        client = _make_client(get_mock)
+        with self.assertRaises(KalshiAPIError):
+            client.get_market("PRESWIN-24-DEM")
+
+    def test_get_orderbook_returns_raw_book(self) -> None:
+        get_mock = mock.Mock(return_value=_StubResponse(_orderbook_payload()))
+        client = _make_client(get_mock)
+
+        book = client.get_orderbook("PRESWIN-24-DEM", depth=5)
+        self.assertIn("yes", book)
+        self.assertIn("no", book)
+        self.assertEqual(book["yes"][0], [58, 1000])
+
+        _, kwargs = get_mock.call_args
+        self.assertEqual(kwargs["params"]["depth"], 5)
+
+    def test_get_orderbook_missing_book_raises(self) -> None:
+        get_mock = mock.Mock(return_value=_StubResponse({"nope": 1}))
+        client = _make_client(get_mock)
+        with self.assertRaises(KalshiAPIError):
+            client.get_orderbook("PRESWIN-24-DEM")
+
+
+# ---------------------------------------------------------------------------
+# normalize_market: missing-field tolerance
+# ---------------------------------------------------------------------------
+
+
+class NormalizeMissingFieldsTest(unittest.TestCase):
+    def test_empty_dict_does_not_crash(self) -> None:
+        norm = normalize_market({})
+        self.assertIsNone(norm["ticker"])
+        self.assertIsNone(norm["title"])
+        self.assertIsNone(norm["yes_bid"])
+        self.assertIsNone(norm["yes_ask"])
+        self.assertIsNone(norm["implied_prob"])
+        self.assertEqual(norm["volume"], 0)
+        self.assertIsNone(norm["close_ts"])
+
+    def test_partial_payload_preserves_known_fields(self) -> None:
+        norm = normalize_market({"ticker": "ONLY", "yes_ask": 55})
+        self.assertEqual(norm["ticker"], "ONLY")
+        self.assertAlmostEqual(norm["yes_ask"], 0.55)
+        self.assertAlmostEqual(norm["implied_prob"], 0.55)
+        self.assertIsNone(norm["no_bid"])
+
+    def test_non_numeric_price_degrades_to_none(self) -> None:
+        norm = normalize_market({"ticker": "X", "yes_ask": "not-a-number"})
+        self.assertIsNone(norm["yes_ask"])
+
+    def test_non_numeric_volume_degrades_to_zero(self) -> None:
+        norm = normalize_market({"ticker": "X", "volume": "garbage"})
+        self.assertEqual(norm["volume"], 0)
+
+    def test_alt_volume_and_close_keys_supported(self) -> None:
+        norm = normalize_market(
+            {"ticker": "X", "volume_24h": 999, "close_ts": "2030-01-01T00:00:00Z"}
+        )
+        self.assertEqual(norm["volume"], 999)
+        self.assertEqual(norm["close_ts"], "2030-01-01T00:00:00Z")
+
+    def test_non_dict_input_raises(self) -> None:
+        with self.assertRaises(KalshiAPIError):
+            normalize_market(["not", "a", "dict"])  # type: ignore[arg-type]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/prediction_market_scanner/test_pnl_ledger.py
+++ b/tests/prediction_market_scanner/test_pnl_ledger.py
@@ -1,0 +1,226 @@
+"""Unit tests for the shadow PnL ledger (``state.pnl_ledger``).
+
+Each test uses a fresh :class:`tempfile.TemporaryDirectory` so the append-only
+JSONL file is isolated and nothing leaks between cases. The ledger is the
+single auditable per-trade truth record, so these tests pin down the
+event-log fold semantics, the no-look-ahead settle guard, and the summary math.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+from state.pnl_ledger import PnlLedger, TradeRecord
+
+
+def _record(
+    *,
+    trade_id: str = "t-1",
+    ts_utc: str = "2026-05-31T12:00:00+00:00",
+    venue: str = "polymarket",
+    market_id: str = "mkt-abc",
+    side: str = "YES",
+    entry_price: float = 0.42,
+    size: float = 100.0,
+    fees_usd: float = 1.50,
+    slippage_bps: float = 5.0,
+    strategy: str = "ev_brain",
+    status: str = "open",
+    notes: str = "",
+) -> TradeRecord:
+    return TradeRecord(
+        trade_id=trade_id,
+        ts_utc=ts_utc,
+        venue=venue,
+        market_id=market_id,
+        side=side,
+        entry_price=entry_price,
+        size=size,
+        fees_usd=fees_usd,
+        slippage_bps=slippage_bps,
+        strategy=strategy,
+        status=status,
+        notes=notes,
+    )
+
+
+class PnlLedgerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        # Point at a nested path to also exercise parent-dir creation.
+        self.path = os.path.join(self._tmp.name, "nested", "pnl_ledger.jsonl")
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_append_then_reload_roundtrip(self) -> None:
+        ledger = PnlLedger(self.path)
+        rec = _record(trade_id="t-roundtrip", entry_price=0.37, notes="hi")
+        ledger.append(rec)
+
+        # Parent dir was created and the file exists on disk.
+        self.assertTrue(os.path.exists(self.path))
+
+        # Re-open from the same path: state must fold back identically.
+        reopened = PnlLedger(self.path)
+        records = reopened.all_records()
+        self.assertEqual(len(records), 1)
+        loaded = records[0]
+        self.assertEqual(loaded.trade_id, "t-roundtrip")
+        self.assertEqual(loaded.entry_price, 0.37)
+        self.assertEqual(loaded.side, "YES")
+        self.assertEqual(loaded.notes, "hi")
+        self.assertEqual(loaded.status, "open")
+        self.assertIsNone(loaded.exit_price)
+
+    def test_settle_updates_realized_pnl_and_win_rate(self) -> None:
+        ledger = PnlLedger(self.path)
+        ledger.append(_record(trade_id="win", strategy="s"))
+        ledger.append(_record(trade_id="loss", strategy="s"))
+
+        ledger.settle(
+            "win",
+            exit_price=0.80,
+            exit_ts_utc="2026-05-31T18:00:00+00:00",
+            market_outcome="YES",
+            realized_pnl_usd=38.0,
+        )
+        ledger.settle(
+            "loss",
+            exit_price=0.10,
+            exit_ts_utc="2026-05-31T18:00:00+00:00",
+            market_outcome="NO",
+            realized_pnl_usd=-42.0,
+        )
+
+        summary = ledger.summary()
+        self.assertEqual(summary["n_trades"], 2)
+        self.assertEqual(summary["n_settled"], 2)
+        self.assertEqual(summary["n_open"], 0)
+        self.assertAlmostEqual(summary["total_realized_pnl_usd"], -4.0)
+        # 1 win out of 2 settled.
+        self.assertAlmostEqual(summary["win_rate"], 0.5)
+        # 2 records * 1.50 fee each.
+        self.assertAlmostEqual(summary["total_fees_usd"], 3.0)
+
+        # The returned record from settle reflects the new state immediately.
+        again = PnlLedger(self.path).settled()
+        self.assertEqual(len(again), 2)
+        win = next(r for r in again if r.trade_id == "win")
+        self.assertEqual(win.status, "settled")
+        self.assertEqual(win.exit_price, 0.80)
+        self.assertEqual(win.market_outcome, "YES")
+        self.assertEqual(win.realized_pnl_usd, 38.0)
+
+    def test_settle_before_entry_raises_lookahead(self) -> None:
+        ledger = PnlLedger(self.path)
+        ledger.append(_record(trade_id="la", ts_utc="2026-05-31T12:00:00+00:00"))
+
+        with self.assertRaises(ValueError):
+            ledger.settle(
+                "la",
+                exit_price=0.50,
+                # One hour BEFORE entry — must be rejected.
+                exit_ts_utc="2026-05-31T11:00:00+00:00",
+                realized_pnl_usd=5.0,
+            )
+
+        # The rejected settle must not have mutated state: still open.
+        self.assertEqual(len(ledger.open_positions()), 1)
+        self.assertEqual(len(ledger.settled()), 0)
+
+    def test_settle_at_exactly_entry_is_allowed(self) -> None:
+        ledger = PnlLedger(self.path)
+        ledger.append(_record(trade_id="eq", ts_utc="2026-05-31T12:00:00+00:00"))
+        # exit == entry is not look-ahead; should succeed.
+        rec = ledger.settle(
+            "eq",
+            exit_price=0.50,
+            exit_ts_utc="2026-05-31T12:00:00+00:00",
+            realized_pnl_usd=1.0,
+        )
+        self.assertEqual(rec.status, "settled")
+
+    def test_empty_and_missing_file_returns_empty_summary(self) -> None:
+        # Missing file (never written).
+        ledger = PnlLedger(self.path)
+        self.assertFalse(os.path.exists(self.path))
+        summary = ledger.summary()
+        self.assertEqual(summary["n_trades"], 0)
+        self.assertEqual(summary["n_settled"], 0)
+        self.assertEqual(summary["n_open"], 0)
+        self.assertEqual(summary["total_realized_pnl_usd"], 0.0)
+        self.assertEqual(summary["win_rate"], 0.0)
+        self.assertEqual(summary["total_fees_usd"], 0.0)
+        self.assertEqual(ledger.open_positions(), [])
+        self.assertEqual(ledger.settled(), [])
+
+        # Explicitly-empty file (touched but no events).
+        os.makedirs(os.path.dirname(self.path), exist_ok=True)
+        with open(self.path, "w", encoding="utf-8"):
+            pass
+        self.assertEqual(PnlLedger(self.path).summary()["n_trades"], 0)
+
+    def test_by_strategy_filter(self) -> None:
+        ledger = PnlLedger(self.path)
+        ledger.append(_record(trade_id="a", strategy="alpha"))
+        ledger.append(_record(trade_id="b", strategy="beta"))
+        ledger.append(_record(trade_id="c", strategy="alpha"))
+
+        alpha = ledger.by_strategy("alpha")
+        self.assertEqual({r.trade_id for r in alpha}, {"a", "c"})
+        beta = ledger.by_strategy("beta")
+        self.assertEqual({r.trade_id for r in beta}, {"b"})
+        self.assertEqual(ledger.by_strategy("missing"), [])
+
+    def test_open_vs_settled_partition(self) -> None:
+        ledger = PnlLedger(self.path)
+        ledger.append(_record(trade_id="still-open"))
+        ledger.append(_record(trade_id="closed"))
+        ledger.settle(
+            "closed",
+            exit_price=0.6,
+            exit_ts_utc="2026-05-31T20:00:00+00:00",
+            realized_pnl_usd=10.0,
+        )
+
+        open_ids = {r.trade_id for r in ledger.open_positions()}
+        settled_ids = {r.trade_id for r in ledger.settled()}
+        self.assertEqual(open_ids, {"still-open"})
+        self.assertEqual(settled_ids, {"closed"})
+        # Partition is exhaustive and disjoint over the two records.
+        self.assertEqual(open_ids & settled_ids, set())
+        self.assertEqual(len(ledger.all_records()), 2)
+
+    def test_settle_appends_event_keeps_entry_line_immutable(self) -> None:
+        ledger = PnlLedger(self.path)
+        ledger.append(_record(trade_id="audit", entry_price=0.33))
+        ledger.settle(
+            "audit",
+            exit_price=0.9,
+            exit_ts_utc="2026-05-31T20:00:00+00:00",
+            realized_pnl_usd=57.0,
+        )
+
+        with open(self.path, "r", encoding="utf-8") as handle:
+            lines = [ln for ln in handle.read().splitlines() if ln.strip()]
+        # Two events: the original open and the settle, both preserved.
+        self.assertEqual(len(lines), 2)
+        self.assertIn('"_event":"open"', lines[0])
+        self.assertIn('"entry_price":0.33', lines[0])
+        self.assertIn('"_event":"settle"', lines[1])
+
+    def test_settle_unknown_trade_raises(self) -> None:
+        ledger = PnlLedger(self.path)
+        with self.assertRaises(KeyError):
+            ledger.settle(
+                "nope",
+                exit_price=0.5,
+                exit_ts_utc="2026-05-31T20:00:00+00:00",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trading/simulator.py
+++ b/trading/simulator.py
@@ -10,6 +10,22 @@ from utils import fmt_money, fmt_pct
 
 
 # ----------------------------
+# Venue fee schedules
+# ----------------------------
+#
+# HONEST COSTS. These mirror the *real* Coinbase Advanced retail fee schedule
+# that the live adapter charges — see
+# ``src/exchanges/adapters/coinbase_tradeable.py`` (``_DEFAULT_COINBASE_FEE_MODEL``,
+# ``FeeModel(maker=0.0040, taker=0.0060)``). Historically the simulator defaulted
+# to ``fee_pct=0.0008`` (8 bps) and left ``maker_fee_pct`` unset, which understated
+# round-trip cost by ~7.5x and made every crypto-1m backtest fictional. We keep the
+# cheap default available for non-Coinbase callers / legacy tests, but the backtest
+# now reaches for these realistic rates via ``SimulationConfig.from_coinbase_fees()``.
+COINBASE_TAKER_FEE_PCT: float = 0.0060  # 60 bps per side
+COINBASE_MAKER_FEE_PCT: float = 0.0040  # 40 bps per side
+
+
+# ----------------------------
 # Data containers
 # ----------------------------
 
@@ -70,6 +86,52 @@ class SimulationConfig:
     breakeven_trigger_short: Optional[float] = None
     record_trades: bool = True
     keep_equity_curve: bool = True
+
+    @classmethod
+    def from_coinbase_fees(
+        cls,
+        *,
+        taker_fee_pct: float = COINBASE_TAKER_FEE_PCT,
+        maker_fee_pct: float = COINBASE_MAKER_FEE_PCT,
+        **kwargs: Any,
+    ) -> "SimulationConfig":
+        """Build a config wired to the *real* Coinbase Advanced retail fees.
+
+        This is the honest cost path. ``fee_pct`` becomes the taker rate
+        (60 bps) and ``maker_fee_pct`` is explicitly set to the maker rate
+        (40 bps) so the maker entry/exit path is no longer fictional. All
+        other ``SimulationConfig`` fields can be overridden via ``kwargs``.
+
+        Round-trip cost under this config:
+          * taker-in + taker-out  = 2 * 60 = ~120 bps
+          * maker-in + maker-out  = 2 * 40 = ~80 bps
+          * taker-in + maker-out  = 60 + 40 = ~100 bps
+
+        Compare to the legacy default (``fee_pct=0.0008``), whose round-trip
+        was only ~16 bps — a ~7.5x understatement.
+        """
+        kwargs.pop("fee_pct", None)
+        kwargs.pop("maker_fee_pct", None)
+        return cls(
+            fee_pct=float(taker_fee_pct),
+            maker_fee_pct=float(maker_fee_pct),
+            **kwargs,
+        )
+
+    @classmethod
+    def from_fee_model(cls, fee_model: Any, **kwargs: Any) -> "SimulationConfig":
+        """Build a config from any ``FeeModel``-like object (duck-typed).
+
+        Accepts the live adapters' ``protocols.FeeModel`` (``.maker``/``.taker``)
+        without importing it here — the two modules live under different import
+        roots. This keeps the simulator the single source of truth for cost while
+        letting venue adapters own their published fee schedule.
+        """
+        return cls.from_coinbase_fees(
+            taker_fee_pct=float(fee_model.taker),
+            maker_fee_pct=float(fee_model.maker),
+            **kwargs,
+        )
 
 
 # ----------------------------
@@ -405,6 +467,14 @@ class PortfolioSimulator:
         return float(bar.best_bid) if order_side > 0 else float(bar.best_ask)
 
     def _post_only_filled(self, order_side: int, limit_price: float, bar: Bar) -> bool:
+        # OPTIMISTIC-FILL ASSUMPTION (look-ahead): a post-only maker order is
+        # placed at this bar's best bid/ask and treated as FILLED if this *same*
+        # bar's low/high crosses the limit. In reality a resting limit posted at
+        # the open would only fill if price came back to it *later* in the bar,
+        # and even then queue position is not guaranteed. This same-bar maker
+        # fill is therefore optimistic and slightly inflates maker fill rates /
+        # understates missed entries. It does NOT touch the fee understatement
+        # this commit fixes; it is flagged here so it is not silently relied on.
         if order_side > 0:
             return float(bar.low) <= float(limit_price)
         return float(bar.high) >= float(limit_price)


### PR DESCRIPTION
CEO/quant profitability review (see docs/PROFITABILITY_PIVOT.md) concluded the crypto 1m directional stack is unprofitable by arithmetic (predicted +10-20bps edge < ~120bps Coinbase round-trip), and the real opportunity is model-free Polymarket arbitrage. This branch builds the rung-0 foundation + the buildable, SHADOW-ONLY Phase-1 edge.

## What shipped (all paper/shadow — no real-money execution)
- **T1/T2 honest fees** — `trading/simulator.py` `from_coinbase_fees()` wires real 60/40bps (was a fictional ~8-16bps with the maker path unwired); `src/backtest.py` now uses real fees by default and persists `gate_passed`/`gate_verdict` to `profit_report.json`.
- **T4 documented crypto kill** — `tests/.../test_fee_honesty_kill.py` proves a perfect +20bps winner nets **-$100** at real fees (+$4 at the old fake fees); `docs/CRYPTO_1M_KILL.md` records the freeze decision.
- **T3 shadow PnL ledger** — `src/state/pnl_ledger.py`, append-only JSONL with a no-look-ahead `settle()` guard.
- **T6/T7 arb detector** — `src/arb_detector.py` intra-market YES+NO<\$1 arbitrage net of fee/gas, logging shadow candidates to the ledger; honest directional EV helper that warns `fair_prob` is a MOCK today. Zero execution code.
- **T8 read-only Kalshi feed** — `src/exchanges/kalshi_market_data.py` for cross-venue gap detection (base URL/auth need live verification).
- **T5 governance** — `docs/PROFITABILITY_PIVOT.md` + `TODOS.md` roadmap + freeze norm.

## Tests
93 tests pass locally (54 new across the 4 modules + 39 adjacent adapter tests). Legacy simulator defaults untouched (no existing test relied on the cheap fee).

## NOT in this PR (gated)
T9 (run the shadow ledger 2-4 weeks), T10-T12 (real Polymarket CLOB execution + live pilot) — real money, explicit deliberate opt-in per the Constitution. Not built autonomously.

Surface: prediction-market scanner + crypto backtest/simulator. No new env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)