### PR TITLE
Whale follower: live mark-to-market P/L + confidence indicator

### DIFF
--- a/src/portfolio_reporter.py
+++ b/src/portfolio_reporter.py
@@ -27,8 +27,13 @@ Pricing convention:
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Sequence
+
+# Recovers a "confidence=0.55 (medium)" marker written into a record's notes by
+# the whale-convergence runner, so it can be surfaced on the Discord card.
+_CONFIDENCE_RE = re.compile(r"confidence=([0-9.]+ \([a-z]+\))")
 
 try:  # Flat import (PYTHONPATH=src), matching the rest of the codebase.
     from state.pnl_ledger import PnlLedger, TradeRecord
@@ -199,17 +204,23 @@ def _trade_fields(rows: List[Dict[str, Any]], *, max_shown: int) -> Dict[str, st
     """Build Discord embed fields, one per trade (capped)."""
     fields: Dict[str, str] = {}
     for row in rows[:max_shown]:
-        title = str(row.get("title") or row.get("market_id") or "market")[:80]
+        full_title = str(row.get("title") or row.get("market_id") or "market")
+        title = full_title[:80]
+        conf_match = _CONFIDENCE_RE.search(full_title)
+        conf_suffix = f" | conf {conf_match.group(1)}" if conf_match else ""
         if "unrealized_pnl_usd" in row:  # open
             pl = row["unrealized_pnl_usd"]
             mark = row.get("current_price")
             mark_str = "pending" if mark is None else f"${mark:.3f}"
             value = (
                 f"{row['side']} | entry ${row['entry_price']:.3f} -> {mark_str} "
-                f"| unrl {_fmt_usd(pl)}"
+                f"| unrl {_fmt_usd(pl)}{conf_suffix}"
             )
         else:  # settled
-            value = f"{row['side']} | realized {_fmt_usd(row.get('realized_pnl_usd'))}"
+            value = (
+                f"{row['side']} | realized {_fmt_usd(row.get('realized_pnl_usd'))}"
+                f"{conf_suffix}"
+            )
         # Discord rejects duplicate-name collisions silently; suffix the id tail.
         key = f"{title} ({str(row.get('trade_id', ''))[-4:]})"
         fields[key[:256]] = value[:1024]

--- a/src/whale_follow_runner.py
+++ b/src/whale_follow_runner.py
@@ -15,19 +15,28 @@ SCOPE — SHADOW-ONLY, NO MONEY MOVES (Constitution: safety first):
 
 Entry price:
     The ``/holders`` endpoint reports holder *amounts*, not prices, so there is
-    no cheap current price available at convergence time. Rather than fabricate
-    a fill price, we record ``entry_price = 0.0`` and flag it in the trade
-    notes; a later settlement supplies the real outcome price. This keeps the
-    ledger honest (no invented fills) per the no-look-ahead standard.
+    no price on the convergence payload itself. By default we record
+    ``entry_price = 0.0`` and flag it in the trade notes; a later settlement
+    supplies the real outcome price. With ``mark_entry=True`` (the CLI default)
+    we instead fetch the converged outcome's *current* market price from the
+    ``/trades`` endpoint — the price you'd pay to follow now, a decision-time
+    entry, NOT look-ahead — and record that as the entry. Either way the
+    ``outcomeIndex=<n>`` marker in the notes lets :func:`make_whale_price_fn`
+    re-price the open position to market for the portfolio report. We never
+    fabricate a fill: when no current price is available we fall back to
+    ``0.0`` (unmarkable), keeping the ledger honest per the no-look-ahead
+    standard.
 """
 
 from __future__ import annotations
 
 import argparse
 import logging
+import re
+import time
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Callable, Dict, List, Optional, Sequence
 
 try:  # Flat import under PYTHONPATH=src (matches the rest of the stack).
     from state.pnl_ledger import DEFAULT_LEDGER_PATH, PnlLedger, TradeRecord
@@ -38,13 +47,28 @@ except Exception:  # pragma: no cover - import shim for alternate layouts.
         TradeRecord,
     )
 
+try:  # Flat import under PYTHONPATH=src (matches the rest of the stack).
+    from exchanges.polymarket_data_api import PolymarketDataAPIError
+except Exception:  # pragma: no cover - import shim for alternate layouts.
+    try:
+        from src.exchanges.polymarket_data_api import (  # type: ignore
+            PolymarketDataAPIError,
+        )
+    except Exception:  # pragma: no cover - keep module importable in minimal envs.
+        class PolymarketDataAPIError(Exception):  # type: ignore
+            """Fallback when the data-api client cannot be imported."""
+
 
 __all__ = [
     "STRATEGY",
     "find_convergence",
     "run_once",
+    "make_whale_price_fn",
     "main",
 ]
+
+# Pulls the ``outcomeIndex=<n>`` marker the runner writes into a record's notes.
+_OUTCOME_INDEX_RE = re.compile(r"outcomeIndex=(\d+)")
 
 
 STRATEGY = "whale_convergence"
@@ -135,6 +159,59 @@ def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _latest_price_for_outcome(
+    client: Any,
+    condition_id: str,
+    outcome_index: int,
+    *,
+    limit: int = 100,
+) -> Optional[float]:
+    """Return the current market price of one outcome of a market.
+
+    Fetches a page of the market's recent trades via
+    ``client.get_trades(market=condition_id, limit=limit)`` and returns the
+    ``price`` of the most-recent (max ``timestamp``) trade whose ``outcomeIndex``
+    matches ``outcome_index``. This is the price you'd pay to FOLLOW the whales
+    *now* — a decision-time entry mark, not a future/look-ahead price.
+
+    The price is validated to lie in ``[0, 1]`` (Polymarket outcome prices are
+    probabilities in dollars). Returns ``None`` on any data-api error, any other
+    exception, an empty page, or when no trade matches the outcome — the caller
+    then falls back to ``entry_price = 0.0`` (unmarkable) rather than fabricate
+    a fill.
+    """
+    try:
+        trades = client.get_trades(market=condition_id, limit=limit)
+    except PolymarketDataAPIError:
+        return None
+    except Exception:  # pragma: no cover - defensive: never let pricing crash a scan.
+        return None
+
+    best_price: Optional[float] = None
+    best_ts: Optional[float] = None
+    for trade in trades or []:
+        if not isinstance(trade, dict):
+            continue
+        if trade.get("outcomeIndex") != outcome_index:
+            continue
+        try:
+            price = float(trade.get("price"))
+        except (TypeError, ValueError):
+            continue
+        if not (0.0 <= price <= 1.0):
+            continue
+        try:
+            ts = float(trade.get("timestamp"))
+        except (TypeError, ValueError):
+            # No usable timestamp: treat as oldest so a timestamped trade wins.
+            ts = float("-inf")
+        if best_ts is None or ts > best_ts:
+            best_ts = ts
+            best_price = price
+
+    return best_price
+
+
 def run_once(
     *,
     ledger: PnlLedger,
@@ -143,6 +220,7 @@ def run_once(
     markets_condition_ids: Sequence[str],
     min_convergence: int = 3,
     size_usd: float = 0.0,
+    mark_entry: bool = False,
 ) -> List[Dict[str, Any]]:
     """Run one convergence scan and log each candidate to the SHADOW ledger.
 
@@ -152,8 +230,17 @@ def run_once(
     The notes flag SHADOW MODE and list the contributing wallets so the
     candidate is auditable. NO orders are placed — the client is read-only.
 
-    Entry price is recorded as ``0.0`` with a note, because ``/holders`` carries
-    no price; see the module docstring.
+    Entry price:
+        * ``mark_entry=False`` (default) — record ``entry_price = 0.0`` with the
+          legacy note, because the ``/holders`` endpoint carries no price. This
+          preserves the original behavior exactly (no ``get_trades`` call).
+        * ``mark_entry=True`` — set ``entry_price`` to the current market price of
+          the converged outcome via :func:`_latest_price_for_outcome` (the price
+          you'd pay to follow now, a decision-time entry — NOT look-ahead). When
+          a real price is found the note reflects it; when none is found we fall
+          back to ``0.0`` and keep the "holders endpoint carries no price" note.
+        Either way the ``outcomeIndex=<n>`` marker is preserved in the notes so
+        :func:`make_whale_price_fn` can re-price the open position later.
 
     Args:
         ledger:                 The shadow :class:`PnlLedger` to append to.
@@ -165,6 +252,8 @@ def run_once(
         min_convergence:        Convergence threshold (default 3).
         size_usd:               Notional label for the shadow record (default
                                 0.0 — shadow positions carry no real size).
+        mark_entry:             When True, fetch a real decision-time entry price
+                                per candidate via the data-api ``/trades`` page.
 
     Returns:
         The list of convergence candidates that were logged.
@@ -185,20 +274,34 @@ def run_once(
             cand.get("outcomeIndex")
         )
         wallets = cand.get("wallets") or []
+        condition_id = str(cand.get("conditionId"))
+        outcome_index = cand.get("outcomeIndex")
+
+        entry_price = 0.0
+        if mark_entry and outcome_index is not None:
+            entry_price = (
+                _latest_price_for_outcome(client, condition_id, outcome_index)
+                or 0.0
+            )
+
+        if entry_price > 0:
+            price_note = f"entry_price={entry_price:.4f} (latest /trades mark)"
+        else:
+            price_note = "entry_price=0.0 (holders endpoint carries no price)"
         notes = (
             "SHADOW MODE - NO ORDERS; "
             f"whale_convergence n={cand.get('n_target_holders')} "
-            f"outcomeIndex={cand.get('outcomeIndex')}; "
-            "entry_price=0.0 (holders endpoint carries no price); "
+            f"outcomeIndex={outcome_index}; "
+            f"{price_note}; "
             f"wallets={','.join(wallets)}"
         )
         record = TradeRecord(
             trade_id=f"whale-{uuid.uuid4().hex[:12]}",
             ts_utc=_utc_now_iso(),
             venue="polymarket",
-            market_id=str(cand.get("conditionId")),
+            market_id=condition_id,
             side=side,
-            entry_price=0.0,
+            entry_price=float(entry_price),
             size=float(size_usd),
             fees_usd=0.0,
             slippage_bps=0.0,
@@ -210,6 +313,29 @@ def run_once(
 
     _print_summary(candidates)
     return candidates
+
+
+def make_whale_price_fn(client: Any) -> Callable[[TradeRecord], Optional[float]]:
+    """Build a ``price_fn(record) -> Optional[float]`` for the portfolio reporter.
+
+    The returned callable re-prices an open whale-convergence position to the
+    current market: it parses the ``outcomeIndex=<n>`` marker out of the record's
+    notes (written by :func:`run_once`) and returns the latest ``/trades`` mark
+    for that market+outcome via :func:`_latest_price_for_outcome`.
+
+    Returns ``None`` (position left "pending", not marked at $0) when the notes
+    carry no ``outcomeIndex`` marker or when the fetch fails — keeping the mark
+    honest per the no-look-ahead / no-fabricated-fill standard.
+    """
+
+    def price_fn(record: TradeRecord) -> Optional[float]:
+        match = _OUTCOME_INDEX_RE.search(record.notes or "")
+        if match is None:
+            return None
+        outcome_index = int(match.group(1))
+        return _latest_price_for_outcome(client, record.market_id, outcome_index)
+
+    return price_fn
 
 
 def _print_summary(candidates: List[Dict[str, Any]]) -> None:
@@ -249,8 +375,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                         help="Pages of recent /trades to harvest candidate wallets from.")
     parser.add_argument("--max-markets", type=int, default=40,
                         help="Max distinct hot markets to scan for convergence.")
-    parser.add_argument("--size", type=float, default=0.0,
-                        help="USD notional label for shadow records (default 0.0).")
+    parser.add_argument("--size", type=float, default=100.0,
+                        help="Paper USD notional per shadow position (default 100.0). "
+                        "Must be >0 for the portfolio report to mark P/L "
+                        "(units = size / entry_price); 0 leaves positions 'pending'.")
     parser.add_argument("--ledger-path", type=str, default=DEFAULT_LEDGER_PATH,
                         help=f"Path to the JSONL PnL ledger (default {DEFAULT_LEDGER_PATH}).")
     parser.add_argument("--discord", action="store_true",
@@ -258,6 +386,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                         "(reads DISCORD_WEBHOOK_URL; no-op if unset).")
     parser.add_argument("--bankroll", type=float, default=1000.0,
                         help="Paper bankroll (USD) baseline for the portfolio report.")
+    parser.add_argument("--interval", type=float, default=None,
+                        help="If set, run continuously, sleeping this many seconds "
+                        "between scans (loop mode). Omit for a single pass.")
+    parser.add_argument("--rank-refresh-scans", type=int, default=48,
+                        help="In loop mode, re-rank smart-money wallets every N scans "
+                        "(default 48); wallets are cached between re-ranks to avoid "
+                        "hammering the per-wallet /positions calls.")
     args = parser.parse_args(argv)
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
@@ -268,51 +403,110 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     import wallet_ranker
 
     client = PolymarketDataAPIClient()
-
-    # 1) Rank smart-money wallets (bounded discovery + per-wallet positions).
-    discovered = wallet_ranker.discover_active_wallets(client, pages=args.discover_pages)
-    ranked = wallet_ranker.rank_wallets(
-        client,
-        candidate_wallets=discovered,
-        min_settled=args.min_settled,
-        min_win_rate=args.min_win_rate,
-        top_n=args.top_wallets,
-    )
-    targets = [w.wallet for w in ranked]
-    print(f"ranked {len(targets)} smart-money wallet(s) from {len(discovered)} active")
-
-    # 2) Candidate markets = the hottest recent markets (by trade recency).
-    market_ids: List[str] = []
-    for trade in client.get_trades(limit=min(500, max(args.max_markets * 10, 100))):
-        cid = trade.get("conditionId") if isinstance(trade, dict) else None
-        if cid and cid not in market_ids:
-            market_ids.append(cid)
-        if len(market_ids) >= args.max_markets:
-            break
-
     ledger = PnlLedger(args.ledger_path)
-    run_once(
-        ledger=ledger,
-        client=client,
-        target_wallets=targets,
-        markets_condition_ids=market_ids,
-        min_convergence=args.min_convergence,
-        size_usd=args.size,
-    )
 
-    if args.discord:
+    # A current-market price_fn so the Discord portfolio report marks each open
+    # whale position to market (entry -> current). It re-prices via /trades using
+    # the outcomeIndex marker in each record's notes; SHADOW/observability only.
+    price_fn = make_whale_price_fn(client)
+
+    def _rank_targets() -> List[str]:
+        """Rank smart-money wallets (bounded discovery + per-wallet positions)."""
+        discovered = wallet_ranker.discover_active_wallets(
+            client, pages=args.discover_pages
+        )
+        ranked = wallet_ranker.rank_wallets(
+            client,
+            candidate_wallets=discovered,
+            min_settled=args.min_settled,
+            min_win_rate=args.min_win_rate,
+            top_n=args.top_wallets,
+        )
+        targets = [w.wallet for w in ranked]
+        print(
+            f"ranked {len(targets)} smart-money wallet(s) from "
+            f"{len(discovered)} active"
+        )
+        return targets
+
+    def _hot_markets() -> List[str]:
+        """Candidate markets = the hottest recent markets (by trade recency)."""
+        market_ids: List[str] = []
+        for trade in client.get_trades(
+            limit=min(500, max(args.max_markets * 10, 100))
+        ):
+            cid = trade.get("conditionId") if isinstance(trade, dict) else None
+            if cid and cid not in market_ids:
+                market_ids.append(cid)
+            if len(market_ids) >= args.max_markets:
+                break
+        return market_ids
+
+    def _report() -> None:
+        if not args.discord:
+            return
         try:
             from portfolio_reporter import load_env_files, report_to_discord
             from alerts.notifier import Notifier
             load_env_files()  # pick up DISCORD_WEBHOOK_URL from .env for CLI runs
             report_to_discord(
-                ledger, Notifier(), bankroll_usd=args.bankroll,
+                ledger, Notifier(), price_fn=price_fn, bankroll_usd=args.bankroll,
                 label="Whale-follow shadow",
             )
         except ImportError:
             logging.warning(
                 "Discord reporting unavailable (alerts/portfolio_reporter import failed)."
             )
+
+    def _scan(targets: Sequence[str]) -> None:
+        market_ids = _hot_markets()
+        run_once(
+            ledger=ledger,
+            client=client,
+            target_wallets=targets,
+            markets_condition_ids=market_ids,
+            min_convergence=args.min_convergence,
+            size_usd=args.size,
+            mark_entry=True,
+        )
+        _report()
+
+    # Single pass (default): rank once, scan once, report, done.
+    if args.interval is None:
+        targets = _rank_targets()
+        _scan(targets)
+        return 0
+
+    # Loop mode: rank on the FIRST iteration, then re-rank every
+    # ``rank_refresh_scans`` iterations (wallets cached between re-ranks so we
+    # don't hammer the N+1 /positions calls on every scan). Each iteration
+    # re-derives hot markets, runs a scan, reports, and sleeps. Ctrl-C exits
+    # cleanly with the no-orders affirmation.
+    refresh = max(1, int(args.rank_refresh_scans))
+    targets: List[str] = []
+    iteration = 0
+    try:
+        while True:
+            try:
+                # Re-rank on schedule, or whenever a prior rank left no roster
+                # (e.g. the first attempt hit a transient API error).
+                if iteration % refresh == 0 or not targets:
+                    targets = _rank_targets()
+                _scan(targets)
+            except KeyboardInterrupt:
+                raise
+            except Exception as exc:  # noqa: BLE001 - a transient API/network
+                # error must NOT kill an unattended shadow loop; log and retry
+                # on the next tick. No orders are ever placed regardless.
+                logging.warning(
+                    "scan iteration %d failed (%s); retrying after interval.",
+                    iteration,
+                    exc,
+                )
+            iteration += 1
+            time.sleep(args.interval)
+    except KeyboardInterrupt:
+        print("\nstopped by user. No orders were ever placed.")
     return 0
 
 

--- a/src/whale_follow_runner.py
+++ b/src/whale_follow_runner.py
@@ -62,6 +62,7 @@ except Exception:  # pragma: no cover - import shim for alternate layouts.
 __all__ = [
     "STRATEGY",
     "find_convergence",
+    "compute_confidence",
     "run_once",
     "make_whale_price_fn",
     "main",
@@ -212,6 +213,36 @@ def _latest_price_for_outcome(
     return best_price
 
 
+def compute_confidence(
+    n_target_holders: int,
+    converging_winrates: Sequence[float],
+    *,
+    min_convergence: int = 3,
+) -> tuple:
+    """Heuristic 0-1 conviction for a whale-convergence candidate.
+
+    This is a SIGNAL-STRENGTH indicator, NOT a probability of profit. It blends:
+      * COUNT — how many smart-money wallets converged on the outcome
+        (saturates at ~6 wallets); and
+      * QUALITY — the average historical win-rate of those converging wallets
+        (mapped 0.50 -> 0.0 .. 0.90 -> 1.0); neutral 0.5 when unknown.
+
+    Returns ``(score, label)`` where label is ``'low'`` (<0.40), ``'medium'``
+    (<0.66), or ``'high'`` (>=0.66). More/better wallets agreeing = higher.
+    """
+    holders = max(int(n_target_holders or 0), int(min_convergence or 0))
+    conv_term = max(0.0, min(1.0, holders / 6.0))
+    rates = [float(r) for r in converging_winrates if isinstance(r, (int, float))]
+    if rates:
+        avg_wr = sum(rates) / len(rates)
+        quality_term = max(0.0, min(1.0, (avg_wr - 0.5) / 0.4))
+    else:
+        quality_term = 0.5  # neutral when wallet quality is unknown
+    score = round(0.5 * conv_term + 0.5 * quality_term, 3)
+    label = "high" if score >= 0.66 else "medium" if score >= 0.40 else "low"
+    return score, label
+
+
 def run_once(
     *,
     ledger: PnlLedger,
@@ -221,6 +252,7 @@ def run_once(
     min_convergence: int = 3,
     size_usd: float = 0.0,
     mark_entry: bool = False,
+    wallet_stats: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
     """Run one convergence scan and log each candidate to the SHADOW ledger.
 
@@ -277,6 +309,28 @@ def run_once(
         condition_id = str(cand.get("conditionId"))
         outcome_index = cand.get("outcomeIndex")
 
+        # Confidence = how many smart-money wallets converged x how good they are
+        # (avg historical win-rate from the ranking). Signal strength, not a
+        # profit probability. Stored on the candidate + in the notes for Discord.
+        winrates: List[float] = []
+        if wallet_stats:
+            for wallet in wallets:
+                stat = wallet_stats.get(wallet)
+                if stat is None:
+                    continue
+                rate = getattr(stat, "win_rate", stat)
+                try:
+                    winrates.append(float(rate))
+                except (TypeError, ValueError):
+                    continue
+        conf_score, conf_label = compute_confidence(
+            int(cand.get("n_target_holders") or len(wallets)),
+            winrates,
+            min_convergence=min_convergence,
+        )
+        cand["confidence"] = conf_score
+        cand["confidence_label"] = conf_label
+
         entry_price = 0.0
         if mark_entry and outcome_index is not None:
             entry_price = (
@@ -291,6 +345,7 @@ def run_once(
         notes = (
             "SHADOW MODE - NO ORDERS; "
             f"whale_convergence n={cand.get('n_target_holders')} "
+            f"confidence={conf_score:.2f} ({conf_label}); "
             f"outcomeIndex={outcome_index}; "
             f"{price_note}; "
             f"wallets={','.join(wallets)}"
@@ -348,6 +403,7 @@ def _print_summary(candidates: List[Dict[str, Any]]) -> None:
             f"outcome={cand.get('outcome')!r} "
             f"(idx {cand.get('outcomeIndex')}) "
             f"n_target_holders={cand.get('n_target_holders')} "
+            f"confidence={cand.get('confidence')} ({cand.get('confidence_label')}) "
             f"wallets={cand.get('wallets')}"
         )
 
@@ -410,6 +466,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     # the outcomeIndex marker in each record's notes; SHADOW/observability only.
     price_fn = make_whale_price_fn(client)
 
+    # wallet -> WalletStats for the current roster, so each convergence candidate
+    # can be scored on the win-rate of the wallets that actually converged.
+    wallet_stats: Dict[str, Any] = {}
+
     def _rank_targets() -> List[str]:
         """Rank smart-money wallets (bounded discovery + per-wallet positions)."""
         discovered = wallet_ranker.discover_active_wallets(
@@ -423,6 +483,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             top_n=args.top_wallets,
         )
         targets = [w.wallet for w in ranked]
+        wallet_stats.clear()
+        wallet_stats.update({w.wallet: w for w in ranked})
         print(
             f"ranked {len(targets)} smart-money wallet(s) from "
             f"{len(discovered)} active"
@@ -468,6 +530,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             min_convergence=args.min_convergence,
             size_usd=args.size,
             mark_entry=True,
+            wallet_stats=wallet_stats,
         )
         _report()
 

--- a/tests/prediction_market_scanner/test_confidence.py
+++ b/tests/prediction_market_scanner/test_confidence.py
@@ -1,0 +1,133 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from state.pnl_ledger import PnlLedger
+import whale_follow_runner as wf
+from portfolio_reporter import _trade_fields
+
+
+class ComputeConfidenceTest(unittest.TestCase):
+    def test_more_holders_raises_score(self):
+        s2, _ = wf.compute_confidence(2, [], min_convergence=2)
+        s5, _ = wf.compute_confidence(5, [], min_convergence=2)
+        self.assertGreater(s5, s2)
+
+    def test_better_wallets_raise_score(self):
+        lo, _ = wf.compute_confidence(3, [0.52, 0.55], min_convergence=3)
+        hi, _ = wf.compute_confidence(3, [0.85, 0.90], min_convergence=3)
+        self.assertGreater(hi, lo)
+
+    def test_labels(self):
+        _, high = wf.compute_confidence(6, [0.9, 0.9], min_convergence=3)
+        _, low = wf.compute_confidence(2, [0.5], min_convergence=2)
+        self.assertEqual(high, "high")
+        self.assertEqual(low, "low")
+
+    def test_neutral_quality_when_no_winrates(self):
+        # conv_term(3/6=0.5) blended with neutral quality(0.5) -> 0.5.
+        score, label = wf.compute_confidence(3, [], min_convergence=3)
+        self.assertAlmostEqual(score, 0.5, places=3)
+        self.assertEqual(label, "medium")
+
+    def test_score_bounded_0_1(self):
+        s, _ = wf.compute_confidence(99, [0.99, 0.99], min_convergence=3)
+        self.assertLessEqual(s, 1.0)
+        s0, _ = wf.compute_confidence(0, [0.1], min_convergence=3)
+        self.assertGreaterEqual(s0, 0.0)
+
+
+class _StatsObj:
+    def __init__(self, win_rate):
+        self.win_rate = win_rate
+
+
+class _HoldersClient:
+    """Fake read-only client: two target wallets hold outcomeIndex 0 of c1."""
+
+    def get_holders(self, condition_id, limit=100):
+        return [
+            {
+                "token": "tok",
+                "holders": [
+                    {"proxyWallet": "wA", "outcomeIndex": 0, "name": "Up"},
+                    {"proxyWallet": "wB", "outcomeIndex": 0, "name": "Up"},
+                ],
+            }
+        ]
+
+
+class RunOnceConfidenceTest(unittest.TestCase):
+    def test_confidence_on_candidate_and_record_notes(self):
+        led = PnlLedger(str(Path(tempfile.mkdtemp()) / "l.jsonl"))
+        cands = wf.run_once(
+            ledger=led,
+            client=_HoldersClient(),
+            target_wallets=["wA", "wB"],
+            markets_condition_ids=["c1"],
+            min_convergence=2,
+            mark_entry=False,  # confidence is independent of entry pricing
+            wallet_stats={"wA": _StatsObj(0.85), "wB": _StatsObj(0.90)},
+        )
+        self.assertEqual(len(cands), 1)
+        self.assertIn("confidence", cands[0])
+        self.assertIn(cands[0]["confidence_label"], ("low", "medium", "high"))
+        # Only 2 converging wallets caps the count term, so even strong
+        # win-rates land 'medium' (2 wallets is not high conviction).
+        self.assertEqual(cands[0]["confidence_label"], "medium")
+        rec = led.open_positions()[0]
+        self.assertRegex(rec.notes, r"confidence=[0-9.]+ \((low|medium|high)\)")
+
+    def test_confidence_computed_without_wallet_stats(self):
+        led = PnlLedger(str(Path(tempfile.mkdtemp()) / "l.jsonl"))
+        cands = wf.run_once(
+            ledger=led,
+            client=_HoldersClient(),
+            target_wallets=["wA", "wB"],
+            markets_condition_ids=["c1"],
+            min_convergence=2,
+            mark_entry=False,
+        )
+        # Neutral quality, still produces a score/label and a notes marker.
+        self.assertIn("confidence", cands[0])
+        self.assertRegex(led.open_positions()[0].notes, r"confidence=")
+
+
+class ReporterConfidenceDisplayTest(unittest.TestCase):
+    def test_confidence_appended_to_discord_field(self):
+        # title carries the record notes (mark_open_position uses notes as title).
+        rows = [
+            {
+                "title": "SHADOW MODE - NO ORDERS; whale_convergence n=2 "
+                "confidence=0.85 (high); outcomeIndex=0; wallets=wA,wB",
+                "market_id": "c1",
+                "side": "Up",
+                "entry_price": 0.50,
+                "current_price": 0.60,
+                "unrealized_pnl_usd": 1.0,
+                "trade_id": "whale-abcd1234",
+            }
+        ]
+        fields = _trade_fields(rows, max_shown=10)
+        joined = " ".join(fields.values())
+        self.assertIn("conf 0.85 (high)", joined)
+
+    def test_no_confidence_marker_is_fine(self):
+        rows = [
+            {
+                "title": "intramarket arb",
+                "market_id": "c1",
+                "side": "YES+NO",
+                "entry_price": 0.97,
+                "current_price": 1.0,
+                "unrealized_pnl_usd": 1.0,
+                "trade_id": "arb-0001",
+            }
+        ]
+        fields = _trade_fields(rows, max_shown=10)
+        joined = " ".join(fields.values())
+        self.assertNotIn("conf ", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/prediction_market_scanner/test_whale_follow_runner.py
+++ b/tests/prediction_market_scanner/test_whale_follow_runner.py
@@ -16,10 +16,17 @@ import tempfile
 import unittest
 from typing import Any, Dict, List
 
-from state.pnl_ledger import PnlLedger
+from state.pnl_ledger import PnlLedger, TradeRecord
+from exchanges.polymarket_data_api import PolymarketDataAPIError
 
 import whale_follow_runner as runner
-from whale_follow_runner import STRATEGY, find_convergence, run_once
+from whale_follow_runner import (
+    STRATEGY,
+    find_convergence,
+    make_whale_price_fn,
+    run_once,
+    _latest_price_for_outcome,
+)
 
 
 def _holder(wallet: str, outcome_index: int, name: str) -> Dict[str, Any]:
@@ -59,6 +66,68 @@ class _FakeClient:
     def get_holders(self, market_condition_id: str, limit: int = 100) -> List[Dict[str, Any]]:
         self.holders_calls.append(market_condition_id)
         return self._holders_by_market.get(market_condition_id, [])
+
+
+def _trade(outcome_index: int, price: float, timestamp: int) -> Dict[str, Any]:
+    """A /trades[] shaped dict with the fields _latest_price_for_outcome reads."""
+    return {
+        "proxyWallet": "0xWHALE",
+        "side": "BUY",
+        "conditionId": "0xCOND",
+        "price": price,
+        "outcome": "Yes" if outcome_index == 0 else "No",
+        "outcomeIndex": outcome_index,
+        "timestamp": timestamp,
+    }
+
+
+class _PricedFakeClient(_FakeClient):
+    """Fake exposing get_holders AND get_trades (current price), still read-only.
+
+    ``get_trades`` returns the per-market canned trade list and records each
+    call so tests can assert whether the price path was exercised.
+    """
+
+    def __init__(
+        self,
+        holders_by_market: Dict[str, List[Dict[str, Any]]],
+        trades_by_market: Dict[str, List[Dict[str, Any]]],
+    ) -> None:
+        super().__init__(holders_by_market)
+        self._trades_by_market = trades_by_market
+        self.trades_calls: List[Dict[str, Any]] = []
+
+    def get_trades(
+        self,
+        user: Any = None,
+        market: Any = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> List[Dict[str, Any]]:
+        self.trades_calls.append({"market": market, "limit": limit})
+        return self._trades_by_market.get(market, [])
+
+
+class _RaisingTradesClient(_FakeClient):
+    """Fake whose get_trades blows up — proves the no-price path is robust AND
+    that mark_entry=False never calls get_trades at all (the test fails loudly
+    if it does)."""
+
+    def __init__(
+        self,
+        holders_by_market: Dict[str, List[Dict[str, Any]]],
+        *,
+        error: Exception = None,
+    ) -> None:
+        super().__init__(holders_by_market)
+        self._error = error or AssertionError(
+            "get_trades must not be called when mark_entry is False"
+        )
+        self.trades_calls = 0
+
+    def get_trades(self, *args: Any, **kwargs: Any) -> List[Dict[str, Any]]:
+        self.trades_calls += 1
+        raise self._error
 
 
 TARGETS = ["0xT1", "0xT2", "0xT3", "0xT4"]
@@ -245,6 +314,199 @@ class RunOnceTest(unittest.TestCase):
         )
         rec = self.ledger.all_records()[0]
         self.assertEqual(rec.size, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# _latest_price_for_outcome: current decision-time entry price
+# ---------------------------------------------------------------------------
+
+
+class LatestPriceForOutcomeTest(unittest.TestCase):
+    def test_picks_max_timestamp_matching_outcome(self) -> None:
+        client = _PricedFakeClient(
+            {},
+            {
+                "0xCOND": [
+                    _trade(0, 0.40, timestamp=100),  # older YES
+                    _trade(0, 0.55, timestamp=300),  # newest YES -> wins
+                    _trade(0, 0.50, timestamp=200),  # middle YES
+                    _trade(1, 0.99, timestamp=999),  # NO: ignored (wrong outcome)
+                ]
+            },
+        )
+        price = _latest_price_for_outcome(client, "0xCOND", 0)
+        self.assertEqual(price, 0.55)
+        # It queried /trades for the right market.
+        self.assertEqual(client.trades_calls[-1]["market"], "0xCOND")
+
+    def test_no_matching_outcome_returns_none(self) -> None:
+        client = _PricedFakeClient(
+            {}, {"0xCOND": [_trade(1, 0.30, timestamp=100)]}
+        )
+        # Asking for outcomeIndex 0 when only outcome 1 traded -> None.
+        self.assertIsNone(_latest_price_for_outcome(client, "0xCOND", 0))
+
+    def test_empty_trades_returns_none(self) -> None:
+        client = _PricedFakeClient({}, {"0xCOND": []})
+        self.assertIsNone(_latest_price_for_outcome(client, "0xCOND", 0))
+
+    def test_data_api_error_returns_none(self) -> None:
+        client = _RaisingTradesClient(
+            {}, error=PolymarketDataAPIError("boom")
+        )
+        self.assertIsNone(_latest_price_for_outcome(client, "0xCOND", 0))
+
+    def test_arbitrary_exception_returns_none(self) -> None:
+        client = _RaisingTradesClient({}, error=RuntimeError("network down"))
+        self.assertIsNone(_latest_price_for_outcome(client, "0xCOND", 0))
+
+    def test_out_of_range_price_skipped(self) -> None:
+        client = _PricedFakeClient(
+            {},
+            {
+                "0xCOND": [
+                    _trade(0, 1.50, timestamp=300),  # invalid (>1), newest -> skipped
+                    _trade(0, 0.42, timestamp=200),  # valid -> wins
+                ]
+            },
+        )
+        self.assertEqual(_latest_price_for_outcome(client, "0xCOND", 0), 0.42)
+
+
+# ---------------------------------------------------------------------------
+# run_once mark_entry: real entry price, and default preserves behavior
+# ---------------------------------------------------------------------------
+
+
+class RunOnceMarkEntryTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self._tmp.name, "pnl_ledger.jsonl")
+        self.ledger = PnlLedger(self.path)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_mark_entry_true_records_latest_matching_price(self) -> None:
+        client = _PricedFakeClient(
+            {"0xCOND": _holders_groups(["0xT1", "0xT2", "0xT3"], [])},
+            {
+                "0xCOND": [
+                    _trade(0, 0.40, timestamp=100),
+                    _trade(0, 0.62, timestamp=500),  # newest YES -> entry price
+                    _trade(1, 0.90, timestamp=900),  # NO: ignored
+                ]
+            },
+        )
+        run_once(
+            ledger=self.ledger,
+            client=client,
+            target_wallets=TARGETS,
+            markets_condition_ids=["0xCOND"],
+            min_convergence=3,
+            mark_entry=True,
+        )
+        rec = self.ledger.all_records()[0]
+        self.assertEqual(rec.entry_price, 0.62)
+        # Notes reflect a real mark, NOT the legacy "entry_price=0.0" claim.
+        self.assertIn("entry_price=0.6200", rec.notes)
+        self.assertNotIn("entry_price=0.0 (holders endpoint", rec.notes)
+        # outcomeIndex marker preserved for later re-pricing.
+        self.assertIn("outcomeIndex=0", rec.notes)
+        self.assertTrue(client.trades_calls)
+
+    def test_mark_entry_true_no_price_falls_back_to_zero(self) -> None:
+        # Holders converge on YES (idx 0) but only NO (idx 1) has traded.
+        client = _PricedFakeClient(
+            {"0xCOND": _holders_groups(["0xT1", "0xT2", "0xT3"], [])},
+            {"0xCOND": [_trade(1, 0.30, timestamp=100)]},
+        )
+        run_once(
+            ledger=self.ledger,
+            client=client,
+            target_wallets=TARGETS,
+            markets_condition_ids=["0xCOND"],
+            min_convergence=3,
+            mark_entry=True,
+        )
+        rec = self.ledger.all_records()[0]
+        self.assertEqual(rec.entry_price, 0.0)
+        self.assertIn("entry_price=0.0 (holders endpoint carries no price)", rec.notes)
+
+    def test_mark_entry_false_records_zero_and_makes_no_trades_call(self) -> None:
+        # If get_trades is called the fake raises AssertionError -> test fails.
+        client = _RaisingTradesClient(
+            {"0xCOND": _holders_groups(["0xT1", "0xT2", "0xT3"], [])}
+        )
+        run_once(
+            ledger=self.ledger,
+            client=client,
+            target_wallets=TARGETS,
+            markets_condition_ids=["0xCOND"],
+            min_convergence=3,
+            # mark_entry defaults to False
+        )
+        rec = self.ledger.all_records()[0]
+        self.assertEqual(rec.entry_price, 0.0)
+        self.assertIn("entry_price=0.0 (holders endpoint carries no price)", rec.notes)
+        self.assertEqual(client.trades_calls, 0)
+
+
+# ---------------------------------------------------------------------------
+# make_whale_price_fn: re-price an open position from its notes marker
+# ---------------------------------------------------------------------------
+
+
+class MakeWhalePriceFnTest(unittest.TestCase):
+    def _record(self, notes: str, market_id: str = "0xCOND") -> TradeRecord:
+        return TradeRecord(
+            trade_id="whale-test",
+            ts_utc="2026-06-01T00:00:00+00:00",
+            venue="polymarket",
+            market_id=market_id,
+            side="Yes",
+            entry_price=0.5,
+            size=0.0,
+            fees_usd=0.0,
+            slippage_bps=0.0,
+            strategy=STRATEGY,
+            status="open",
+            notes=notes,
+        )
+
+    def test_parses_outcome_index_and_returns_fetched_price(self) -> None:
+        client = _PricedFakeClient(
+            {},
+            {
+                "0xCOND": [
+                    _trade(1, 0.10, timestamp=100),  # NO: ignored
+                    _trade(1, 0.73, timestamp=400),  # newest NO -> returned
+                ]
+            },
+        )
+        price_fn = make_whale_price_fn(client)
+        record = self._record(
+            "SHADOW MODE - NO ORDERS; whale_convergence n=3 outcomeIndex=1; "
+            "entry_price=0.0 (holders endpoint carries no price); wallets=0xT1,0xT2,0xT3"
+        )
+        self.assertEqual(price_fn(record), 0.73)
+        self.assertEqual(client.trades_calls[-1]["market"], "0xCOND")
+
+    def test_returns_none_when_notes_have_no_outcome_index(self) -> None:
+        client = _PricedFakeClient(
+            {}, {"0xCOND": [_trade(0, 0.50, timestamp=100)]}
+        )
+        price_fn = make_whale_price_fn(client)
+        record = self._record("no marker here at all")
+        self.assertIsNone(price_fn(record))
+        # Without an outcomeIndex we must not even hit /trades.
+        self.assertEqual(client.trades_calls, [])
+
+    def test_returns_none_when_fetch_fails(self) -> None:
+        client = _RaisingTradesClient({}, error=PolymarketDataAPIError("boom"))
+        price_fn = make_whale_price_fn(client)
+        record = self._record("whale_convergence outcomeIndex=0;")
+        self.assertIsNone(price_fn(record))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two commits on top of merged main (#11/#12). Clean 4-file diff.

## 1. Real entry price + mark-to-market (was committed but never pushed before #11/#12 merged)
- whale convergence records a real decision-time entry price (latest /trades for the converged outcome), and the Discord portfolio report re-marks each open position to current price. So per-trade P/L is now real and moves (e.g. entry $0.54 -> mark $0.09 = -$83 unrl).
- `--interval` loop re-ranks wallets only every `--rank-refresh-scans` (cached) to avoid hammering the N+1 /positions calls; per-iteration errors are caught (log + retry) so a transient 429/network blip can't kill the unattended loop. `--size` defaults to 100 so P/L actually marks.

## 2. Confidence-level indicator (this request)
- Each convergence candidate gets a 0-1 confidence score + low/medium/high label, blending how MANY smart-money wallets converged with how GOOD they are (avg historical win-rate). Shown on every Discord card: `Up | entry $0.54 -> $0.09 | unrl -$83 | conf 0.55 (medium)`. Signal strength, NOT a profit probability.

All SHADOW-ONLY (no orders). Adversarially verified (no order code, no look-ahead, rate-limit safe). 56 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)