### PR TITLE
Leaderboard roster + recalibration + do-not-trade blocklist + dedup

### DIFF
--- a/scripts/optimize_exits.py
+++ b/scripts/optimize_exits.py
@@ -1,0 +1,390 @@
+"""Optimize whale-follow stop-loss / take-profit on REAL resolved winner positions.
+
+This is the READ-ONLY live half of the exit-overlay study. It pulls the top profit
+winners off the Polymarket leaderboard, reconstructs each winner's REAL resolved
+positions and the forward price path they sat through, then sweeps a grid of
+stop-loss / take-profit thresholds via :func:`exit_backtest.grid_search` to find the
+overlay that would have improved the realized return — and reports it against the
+baseline of doing nothing (hold to resolution).
+
+SCOPE — READ-ONLY, NO MONEY MOVES (Constitution: safety first):
+    This script issues ONLY data reads through :class:`PolymarketDataAPIClient`
+    (``get_profit_leaderboard`` / ``get_positions`` / ``get_trades``). It places no
+    orders, signs nothing, redeems nothing, and touches no wallet/web3 path. The
+    grid search is a pure offline computation. Nothing here moves money.
+
+No look-ahead:
+    For each resolved position the whale's ENTRY timestamp is found from THEIR OWN
+    trades on that outcome (the min timestamp on the matching outcomeIndex). The
+    forward price path is then built ONLY from market trades on that same outcome
+    with ``timestamp > entry_ts`` — strictly post-entry prices. The exit simulation
+    consumes that path in time order and never consults the resolved outcome until
+    the path is exhausted. So every exit decision uses only information that was
+    observable at decision time. Positions with no usable post-entry path are
+    skipped (counted), never backfilled with a guessed price.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SRC_DIR = _REPO_ROOT / "src"
+for _p in (_SRC_DIR, _REPO_ROOT):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+from exchanges.polymarket_data_api import (  # noqa: E402
+    PolymarketDataAPIClient,
+    PolymarketDataAPIError,
+)
+from exit_backtest import grid_search  # noqa: E402
+
+
+# The grid swept by default. ``None`` on each axis tests "no stop" / "no TP", so the
+# baseline (all-None hold-to-resolution) is always part of the search.
+SL_VALUES: List[Optional[float]] = [None, 0.2, 0.3, 0.4, 0.5, 0.6]
+TP_PCT_VALUES: List[Optional[float]] = [None, 0.3, 0.5, 0.75, 1.0]
+TP_PRICE_VALUES: List[Optional[float]] = [None, 0.85, 0.90, 0.95]
+
+
+def _is_resolved(position: Dict[str, Any]) -> bool:
+    """A position is RESOLVED iff redeemable, or its curPrice is pinned to 0/1.
+
+    A settled Polymarket outcome marks to exactly $0 (lost) or $1 (won); we treat
+    ``curPrice`` within 1e-3 of either bound, OR an explicit ``redeemable: true``,
+    as resolved. Anything else is still open and is left out of the dataset.
+    """
+    if position.get("redeemable") is True:
+        return True
+    try:
+        cur = float(position.get("curPrice"))
+    except (TypeError, ValueError):
+        return False
+    return cur <= 0.001 or cur >= 0.999
+
+
+def _final_price(position: Dict[str, Any]) -> float:
+    """Resolved price of the held outcome: 1.0 (won) or 0.0 (lost).
+
+    Uses ``curPrice`` when it is pinned near a bound; otherwise (a redeemable
+    position whose curPrice is mid-range or missing) falls back to ``redeemable``
+    meaning a winning, redeemable claim -> 1.0, else 0.0. This is intentionally
+    conservative: a redeemable position is one the wallet can claim, i.e. it won.
+    """
+    try:
+        cur = float(position.get("curPrice"))
+    except (TypeError, ValueError):
+        cur = None
+    if cur is not None:
+        if cur >= 0.999:
+            return 1.0
+        if cur <= 0.001:
+            return 0.0
+    # Mid-range/missing curPrice but redeemable: a claimable position is a win.
+    return 1.0 if position.get("redeemable") is True else 0.0
+
+
+def _entry_ts(
+    client: PolymarketDataAPIClient,
+    wallet: str,
+    condition_id: str,
+    outcome_index: int,
+    *,
+    limit: int = 500,
+) -> Optional[int]:
+    """The whale's ENTRY timestamp on this outcome: min ts over THEIR own trades.
+
+    Fetches the wallet's trades on this market and returns the earliest timestamp
+    among trades matching ``outcome_index``. Returns ``None`` on any data-api error
+    or when no matching trade carries a usable timestamp — the caller then skips the
+    position rather than guess an entry time.
+    """
+    try:
+        trades = client.get_trades(user=wallet, market=condition_id, limit=limit)
+    except PolymarketDataAPIError:
+        return None
+
+    earliest: Optional[int] = None
+    for trade in trades or []:
+        if not isinstance(trade, dict):
+            continue
+        if trade.get("outcomeIndex") != outcome_index:
+            continue
+        try:
+            ts = int(trade.get("timestamp"))
+        except (TypeError, ValueError):
+            continue
+        if earliest is None or ts < earliest:
+            earliest = ts
+    return earliest
+
+
+def _forward_path(
+    client: PolymarketDataAPIClient,
+    condition_id: str,
+    outcome_index: int,
+    entry_ts: int,
+    *,
+    limit: int = 500,
+    max_pages: int = 6,
+) -> tuple:
+    """Build the post-entry price path for one outcome (NO look-ahead).
+
+    Paginates the market's trades (the data-api returns them newest-first) and
+    keeps ONLY those on ``outcome_index`` with ``timestamp > entry_ts`` (strictly
+    after the whale entered), sorted ascending by timestamp. Walks back page by
+    page until a page's oldest trade is at/before ``entry_ts`` (the full
+    post-entry window is covered) or ``max_pages`` is hit.
+
+    Returns ``(path, truncated)``. ``truncated`` is True when the page cap was
+    reached before getting back to ``entry_ts`` — the path may then miss the
+    EARLIEST post-entry prices (a backtest bias that can understate a stop-loss,
+    NOT look-ahead). Prices validated to ``[0, 1]``.
+    """
+    rows: List[tuple] = []
+    truncated = False
+    offset = 0
+    for _page in range(max_pages):
+        try:
+            trades = client.get_trades(
+                market=condition_id, limit=limit, offset=offset
+            )
+        except PolymarketDataAPIError:
+            break
+        if not trades:
+            break
+        oldest_on_page = None
+        for trade in trades:
+            if not isinstance(trade, dict):
+                continue
+            try:
+                ts = int(trade.get("timestamp"))
+            except (TypeError, ValueError):
+                continue
+            if oldest_on_page is None or ts < oldest_on_page:
+                oldest_on_page = ts
+            if trade.get("outcomeIndex") != outcome_index:
+                continue
+            try:
+                price = float(trade.get("price"))
+            except (TypeError, ValueError):
+                continue
+            if ts <= entry_ts or not (0.0 <= price <= 1.0):
+                continue
+            rows.append((ts, price))
+        # Newest-first paging: once a page reaches at/before entry_ts the whole
+        # post-entry window is covered; a short page means no more trades.
+        if oldest_on_page is not None and oldest_on_page <= entry_ts:
+            break
+        if len(trades) < limit:
+            break
+        offset += limit
+    else:
+        truncated = True
+
+    rows.sort(key=lambda r: r[0])
+    return [price for _ts, price in rows], truncated
+
+
+def collect_samples(
+    client: PolymarketDataAPIClient,
+    *,
+    top_wallets: int,
+    max_positions_per_wallet: int,
+    max_samples: int,
+    window: str,
+) -> List[Dict[str, Any]]:
+    """Assemble the backtest dataset from real resolved winner positions.
+
+    Pulls the top ``top_wallets`` profit-leaderboard wallets, and for each (bounded
+    by ``max_positions_per_wallet`` and the global ``max_samples`` cap) reconstructs
+    its resolved positions into ``{'entry_price', 'price_path', 'final_price'}``
+    samples. Read-only and bounded; prints progress as it goes.
+    """
+    print(f"[1/2] fetching profit leaderboard (window={window!r}, top={top_wallets}) ...")
+    try:
+        rows = client.get_profit_leaderboard(window=window, limit=top_wallets)
+    except PolymarketDataAPIError as exc:
+        print(f"  leaderboard fetch failed: {exc}")
+        return []
+
+    wallets: List[str] = []
+    for row in rows:
+        wallet = row.get("proxyWallet") if isinstance(row, dict) else None
+        if wallet and wallet not in wallets:
+            wallets.append(wallet)
+        if len(wallets) >= top_wallets:
+            break
+    print(f"  got {len(wallets)} wallet(s)")
+
+    samples: List[Dict[str, Any]] = []
+    n_truncated = 0
+    print(f"[2/2] reconstructing resolved positions (cap {max_samples} samples) ...")
+    for w_idx, wallet in enumerate(wallets):
+        if len(samples) >= max_samples:
+            break
+        try:
+            positions = client.get_positions(user=wallet)
+        except PolymarketDataAPIError as exc:
+            print(f"  wallet {w_idx + 1}/{len(wallets)} {wallet[:10]}.. positions failed: {exc}")
+            continue
+
+        kept_this_wallet = 0
+        for position in positions:
+            if len(samples) >= max_samples or kept_this_wallet >= max_positions_per_wallet:
+                break
+            if not isinstance(position, dict):
+                continue
+            if not _is_resolved(position):
+                continue
+            try:
+                entry_price = float(position.get("avgPrice"))
+            except (TypeError, ValueError):
+                continue
+            if entry_price <= 0:
+                continue
+            condition_id = position.get("conditionId")
+            outcome_index = position.get("outcomeIndex")
+            if not condition_id or outcome_index is None:
+                continue
+
+            entry_ts = _entry_ts(client, wallet, condition_id, outcome_index)
+            if entry_ts is None:
+                continue
+            path, path_truncated = _forward_path(
+                client, condition_id, outcome_index, entry_ts
+            )
+            if not path:
+                continue
+            if path_truncated:
+                n_truncated += 1
+
+            samples.append(
+                {
+                    "entry_price": entry_price,
+                    "price_path": path,
+                    "final_price": _final_price(position),
+                    # Bookkeeping (not used by grid_search; aids inspection):
+                    "wallet": wallet,
+                    "conditionId": condition_id,
+                    "outcomeIndex": outcome_index,
+                    "title": position.get("title"),
+                }
+            )
+            kept_this_wallet += 1
+
+        print(
+            f"  wallet {w_idx + 1}/{len(wallets)} {wallet[:10]}.. "
+            f"kept {kept_this_wallet} resolved position(s); total samples={len(samples)}"
+        )
+
+    if n_truncated:
+        print(
+            f"  NOTE: {n_truncated}/{len(samples)} sample path(s) hit the page cap "
+            f"-- may miss the earliest post-entry prices (backtest bias, can "
+            f"understate stop-loss; not look-ahead)."
+        )
+    return samples
+
+
+def _fmt_combo(combo: Optional[Dict[str, Any]]) -> str:
+    """One-line human summary of a combo aggregate."""
+    if combo is None:
+        return "(none)"
+    return (
+        f"sl={combo['stop_loss_pct']} tp%={combo['take_profit_pct']} "
+        f"tp$={combo['take_profit_price']} | "
+        f"n={combo['n']} mean={combo['mean_return']:+.4f} "
+        f"win={combo['win_rate']:.1%} worst={combo['worst_return']:+.4f} "
+        f"mix={combo['exit_mix']}"
+    )
+
+
+def run(args: argparse.Namespace) -> int:
+    """Collect the dataset, run the grid search, and print the verdict."""
+    client = PolymarketDataAPIClient()
+
+    samples = collect_samples(
+        client,
+        top_wallets=args.top_wallets,
+        max_positions_per_wallet=args.max_positions_per_wallet,
+        max_samples=args.max_samples,
+        window=args.window,
+    )
+
+    print()
+    print(f"dataset: {len(samples)} resolved-position sample(s)")
+    if not samples:
+        print("no usable samples (no post-entry price paths); nothing to optimize.")
+        return 1
+
+    result = grid_search(
+        samples,
+        sl_values=SL_VALUES,
+        tp_pct_values=TP_PCT_VALUES,
+        tp_price_values=TP_PRICE_VALUES,
+        fee_bps=args.fee_bps,
+    )
+
+    baseline = result["baseline"]
+    print()
+    print("BASELINE (hold to resolution, no overlay):")
+    print(f"  {_fmt_combo(baseline)}")
+
+    print()
+    print("TOP 8 combos by mean_return:")
+    for combo in result["combos"][:8]:
+        print(f"  {_fmt_combo(combo)}")
+
+    print()
+    print("RECOMMENDED (best risk_adjusted: max mean_return with worst_return >= -0.6):")
+    print(f"  {_fmt_combo(result['risk_adjusted'])}")
+    rec = result["risk_adjusted"]
+    if rec is not None and baseline["n"]:
+        delta = rec["mean_return"] - baseline["mean_return"]
+        print(f"  improvement over baseline mean_return: {delta:+.4f}")
+
+    if args.out:
+        out_path = Path(args.out)
+        payload = {
+            "window": args.window,
+            "fee_bps": args.fee_bps,
+            "n_samples": len(samples),
+            "baseline": baseline,
+            "best_by_meanret": result["best_by_meanret"],
+            "risk_adjusted": result["risk_adjusted"],
+            "combos": result["combos"],
+        }
+        out_path.write_text(json.dumps(payload, indent=2, default=str))
+        print(f"\nwrote {out_path}")
+
+    return 0
+
+
+def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Optimize whale-follow stop-loss / take-profit on REAL resolved "
+            "winner positions (READ-ONLY; no orders)."
+        )
+    )
+    parser.add_argument("--top-wallets", type=int, default=25)
+    parser.add_argument("--max-positions-per-wallet", type=int, default=20)
+    parser.add_argument("--max-samples", type=int, default=250)
+    parser.add_argument("--window", default="all")
+    parser.add_argument("--fee-bps", type=float, default=200.0)
+    parser.add_argument("--out", default=None, help="optional JSON path for full results")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    return run(_parse_args(argv))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/dashboard/__init__.py
+++ b/src/dashboard/__init__.py
@@ -1,0 +1,7 @@
+"""Read-only observability dashboard for the whale-follow SHADOW loop.
+
+This package is OBSERVABILITY ONLY. It reads the append-only PnL ledger
+(:mod:`state.pnl_ledger`) via :func:`portfolio_reporter.build_report` and serves
+a self-contained web page over stdlib ``http.server``. It places NO orders and
+never mutates the ledger or any other file.
+"""

--- a/src/dashboard/server.py
+++ b/src/dashboard/server.py
@@ -1,0 +1,150 @@
+"""Stdlib HTTP server for the read-only SHADOW dashboard.
+
+OBSERVABILITY ONLY. This server exposes exactly two GET endpoints and nothing
+else:
+
+* ``GET /``           -> the self-contained dashboard HTML page.
+* ``GET /api/state``  -> ``build_state(PnlLedger(ledger_path))`` as JSON.
+
+There is no order, trade, settle, or any other write surface here. The ledger is
+opened read-only and re-read on every ``/api/state`` request (a cheap JSONL fold),
+so the page always reflects the latest appended events without holding the file
+open or caching stale state. Built on :class:`http.server.ThreadingHTTPServer` so
+the 4s poll from a couple of browser tabs never blocks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Dict
+
+# Deliberate sys.path bootstrap (matches main.py / src/orchestrator.py): ensure
+# the repo's ``src/`` is importable so the flat imports below resolve even when
+# this file is launched as a script path (``python src/dashboard/server.py``),
+# where sys.path[0] is ``src/dashboard`` rather than ``src``. Read-only.
+_SRC_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _SRC_DIR not in sys.path:
+    sys.path.insert(0, _SRC_DIR)
+
+from dashboard.state import build_state  # noqa: E402
+from state.pnl_ledger import PnlLedger  # noqa: E402
+
+# The dashboard's single static asset lives next to this module.
+_STATIC_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "static")
+_INDEX_HTML = os.path.join(_STATIC_DIR, "index.html")
+
+# Default ledger for the whale-follow shadow loop (overridable via --ledger-path).
+DEFAULT_WHALE_LEDGER = "runs/whale_optimized_ledger.jsonl"
+
+
+def make_handler(ledger_path: str, bankroll_usd: float):
+    """Build a request-handler class bound to a ledger path + bankroll.
+
+    Returning a closure-bound subclass keeps the server config off of mutable
+    globals while still fitting the stdlib ``BaseHTTPRequestHandler`` contract.
+    """
+
+    class DashboardHandler(BaseHTTPRequestHandler):
+        # Identify ourselves plainly; this is a local observability tool.
+        server_version = "ShadowDashboard/1.0"
+
+        def _send(self, status: int, body: bytes, content_type: str) -> None:
+            self.send_response(status)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body)))
+            # Always serve fresh state; the page polls on an interval.
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _send_json(self, status: int, payload: Dict[str, Any]) -> None:
+            body = json.dumps(payload).encode("utf-8")
+            self._send(status, body, "application/json; charset=utf-8")
+
+        def do_GET(self) -> None:  # noqa: N802 - stdlib handler naming.
+            # Strip any query string; we have no query-driven endpoints.
+            path = self.path.split("?", 1)[0]
+
+            if path == "/":
+                try:
+                    with open(_INDEX_HTML, "rb") as handle:
+                        body = handle.read()
+                except OSError:
+                    self._send_json(500, {"error": "dashboard page missing"})
+                    return
+                self._send(200, body, "text/html; charset=utf-8")
+                return
+
+            if path == "/api/state":
+                try:
+                    ledger = PnlLedger(ledger_path)
+                    state = build_state(ledger, bankroll_usd=bankroll_usd)
+                except Exception as exc:  # noqa: BLE001 - report, never crash the server.
+                    self._send_json(500, {"error": f"failed to build state: {exc}"})
+                    return
+                self._send_json(200, state)
+                return
+
+            # Everything else is a hard 404 — there is no other surface.
+            self._send_json(404, {"error": "not found"})
+
+        # POST/PUT/etc. are simply not implemented: BaseHTTPRequestHandler
+        # returns 501 for any verb without a do_<VERB>, so there is provably no
+        # write path. We intentionally do NOT define do_POST or any mutator.
+
+        def log_message(self, fmt: str, *args: Any) -> None:
+            # Keep the console quiet but informative: method + path + status.
+            try:
+                print(f"[dashboard] {self.address_string()} {fmt % args}")
+            except Exception:  # pragma: no cover - logging must never crash.
+                pass
+
+    return DashboardHandler
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Read-only web dashboard for the whale-follow SHADOW loop."
+    )
+    parser.add_argument(
+        "--port", type=int, default=8888, help="HTTP port to listen on (default 8888)."
+    )
+    parser.add_argument(
+        "--ledger-path",
+        default=DEFAULT_WHALE_LEDGER,
+        help=f"PnL ledger JSONL to read (default {DEFAULT_WHALE_LEDGER}).",
+    )
+    parser.add_argument(
+        "--bankroll",
+        type=float,
+        default=1000.0,
+        help="Starting bankroll in USD for equity math (default 1000).",
+    )
+    args = parser.parse_args(argv)
+
+    handler = make_handler(args.ledger_path, args.bankroll)
+    server = ThreadingHTTPServer(("127.0.0.1", args.port), handler)
+
+    url = f"http://127.0.0.1:{args.port}/"
+    abs_ledger = os.path.abspath(args.ledger_path)
+    print(f"SHADOW dashboard (read-only) serving {url}")
+    print(f"  ledger:   {abs_ledger}")
+    print(f"  bankroll: ${args.bankroll:,.2f}")
+    if not os.path.exists(args.ledger_path):
+        print("  note: ledger file does not exist yet — page will show an empty book.")
+    print("  Ctrl-C to stop.")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nshutting down.")
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/dashboard/state.py
+++ b/src/dashboard/state.py
@@ -37,11 +37,7 @@ if _SRC_DIR not in sys.path:
     sys.path.insert(0, _SRC_DIR)
 
 from portfolio_reporter import DEFAULT_BANKROLL_USD, build_report  # noqa: E402
-from state.pnl_ledger import (  # noqa: E402
-    PnlLedger,
-    TradeRecord,
-    dedupe_open_positions,
-)
+from state.pnl_ledger import PnlLedger, TradeRecord  # noqa: E402
 
 __all__ = ["build_state", "parse_confidence", "clean_title", "normalize_exit_reason"]
 
@@ -139,7 +135,7 @@ def build_state(
     # on the ledger) to one position each — we shadow ONE unit per (market,
     # outcome), so both the count and the cards must treat a dup as one. This is
     # why ``n_open`` is taken from the deduped list rather than ``report``.
-    deduped_open = dedupe_open_positions(ledger.open_positions())
+    deduped_open = ledger.unique_open_positions()
 
     summary = {
         "equity_usd": float(report.get("equity_usd", bankroll_usd)),

--- a/src/dashboard/state.py
+++ b/src/dashboard/state.py
@@ -1,0 +1,211 @@
+"""Pure, testable view-state builder for the SHADOW dashboard.
+
+This module turns a :class:`state.pnl_ledger.PnlLedger` into a single JSON-able
+``dict`` the web UI can render directly. It is intentionally free of any sockets,
+HTTP, or I/O beyond reading the ledger through the already-audited
+:func:`portfolio_reporter.build_report` and the ledger's own read methods — so it
+can be unit-tested without standing up a server.
+
+OBSERVABILITY ONLY: nothing here places orders or mutates the ledger. We read the
+ledger and shape it for display; that is the entire contract.
+
+Key shaping decisions
+---------------------
+* ``build_report`` is called with ``price_fn=None`` on purpose: we never fetch a
+  live mark on the request path (that would make every page-load slow and hit the
+  network). Open positions are therefore shown at their entry with their recorded
+  confidence; unrealized P/L stays "pending".
+* The exit-mix / equity-curve are derived from the *settled* records only, which
+  are the honest realized track record (no look-ahead — every settlement already
+  happened at an observed mark or a real resolution).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from typing import Any, Dict, List, Optional
+
+# Deliberate sys.path bootstrap (matches main.py / src/orchestrator.py): ensure
+# the repo's ``src/`` is importable so the flat ``from portfolio_reporter import
+# ...`` / ``from state.pnl_ledger import ...`` imports resolve even when this file
+# is run via a script path (``python src/dashboard/server.py``), where sys.path[0]
+# is ``src/dashboard`` rather than ``src``. Read-only; touches no files.
+_SRC_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _SRC_DIR not in sys.path:
+    sys.path.insert(0, _SRC_DIR)
+
+from portfolio_reporter import DEFAULT_BANKROLL_USD, build_report  # noqa: E402
+from state.pnl_ledger import PnlLedger, TradeRecord  # noqa: E402
+
+__all__ = ["build_state", "parse_confidence", "clean_title", "normalize_exit_reason"]
+
+# Recovers a "confidence=0.65 (medium)" marker written into a record's notes by
+# the whale-convergence runner. Group 1 = numeric score, group 2 = label.
+_CONFIDENCE_RE = re.compile(r"confidence=([0-9.]+) \(([a-z]+)\)")
+
+# An optional "title=..." marker in notes, should the runner ever embed a clean
+# human title. Today's notes don't carry one, so we fall back to a short id.
+_TITLE_RE = re.compile(r"title=([^;]+)")
+
+
+def parse_confidence(notes: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Parse ``confidence=0.XX (label)`` out of a record's notes.
+
+    Returns ``{"score": float, "label": str}`` or ``None`` when no confidence
+    marker is present (or notes is missing).
+    """
+    if not notes:
+        return None
+    match = _CONFIDENCE_RE.search(notes)
+    if not match:
+        return None
+    try:
+        score = float(match.group(1))
+    except (TypeError, ValueError):
+        return None
+    return {"score": score, "label": match.group(2)}
+
+
+def clean_title(*, notes: Optional[str], market_id: Optional[str]) -> str:
+    """Best clean display title for a position.
+
+    Prefers an explicit ``title=...`` marker in notes if present; otherwise falls
+    back to a short, readable slice of the (typically hex) ``market_id``.
+    """
+    if notes:
+        match = _TITLE_RE.search(notes)
+        if match:
+            title = match.group(1).strip()
+            if title:
+                return title
+    mid = (market_id or "").strip()
+    if not mid:
+        return "market"
+    # Hex condition ids are long; show a recognizable head…tail slug.
+    if len(mid) > 16:
+        return f"{mid[:10]}…{mid[-4:]}"
+    return mid
+
+
+def normalize_exit_reason(
+    market_outcome: Optional[Any],
+    realized_pnl_usd: Optional[float],
+) -> str:
+    """Normalize a settled record into one of four exit-mix buckets.
+
+    ``market_outcome`` strings that start with ``"exit:"`` (written by the exit
+    rules) map to ``"take_profit"`` / ``"stop_loss"`` (anything else after the
+    prefix falls back to the raw reason). All other settlements are *resolutions*:
+    a positive realized P/L is ``"won"``, otherwise ``"lost"``.
+    """
+    outcome = market_outcome if isinstance(market_outcome, str) else ""
+    if outcome.startswith("exit:"):
+        reason = outcome[len("exit:"):].strip()
+        return reason or "exit"
+    pnl = realized_pnl_usd if isinstance(realized_pnl_usd, (int, float)) else 0.0
+    return "won" if pnl > 0 else "lost"
+
+
+def _exit_ts_key(value: Optional[str]) -> str:
+    """Sort key for ISO-8601 exit timestamps that tolerates ``None``.
+
+    ISO-8601 sorts lexicographically in chronological order, so the raw string is
+    a fine key; ``None``/missing timestamps sort first (treated as oldest).
+    """
+    return value or ""
+
+
+def build_state(
+    ledger: PnlLedger,
+    *,
+    bankroll_usd: float = DEFAULT_BANKROLL_USD,
+) -> Dict[str, Any]:
+    """Build the full dashboard view-state from ``ledger``.
+
+    Returns a JSON-able dict with ``summary``, ``open_positions``,
+    ``closed_positions`` (exit feed, newest first), ``exit_mix``, and
+    ``equity_curve`` (realized track record over time). Robust to missing/None
+    fields on any record.
+    """
+    report = build_report(ledger, price_fn=None, bankroll_usd=bankroll_usd)
+
+    summary = {
+        "equity_usd": float(report.get("equity_usd", bankroll_usd)),
+        "realized_pnl_usd": float(report.get("realized_pnl_usd", 0.0)),
+        "unrealized_pnl_usd": float(report.get("unrealized_pnl_usd", 0.0)),
+        "win_rate": float(report.get("win_rate", 0.0)),
+        "n_open": int(report.get("n_open", 0)),
+        "n_settled": int(report.get("n_settled", 0)),
+        "total_fees_usd": float(report.get("total_fees_usd", 0.0)),
+        "bankroll_usd": float(bankroll_usd),
+    }
+
+    # --- Open positions: clean title + parsed confidence (entry only, no mark) ---
+    open_positions: List[Dict[str, Any]] = []
+    for record in ledger.open_positions():
+        notes = getattr(record, "notes", "") or ""
+        market_id = getattr(record, "market_id", "") or ""
+        entry_price = getattr(record, "entry_price", None)
+        open_positions.append(
+            {
+                "title": clean_title(notes=notes, market_id=market_id),
+                "side": getattr(record, "side", "") or "",
+                "entry_price": (
+                    float(entry_price) if isinstance(entry_price, (int, float)) else None
+                ),
+                "confidence": parse_confidence(notes),
+                "strategy": getattr(record, "strategy", "") or "",
+            }
+        )
+
+    # --- Settled records: shared source for the exit feed, mix, and curve. ---
+    settled: List[TradeRecord] = list(ledger.settled())
+
+    closed_positions: List[Dict[str, Any]] = []
+    exit_mix: Dict[str, int] = {}
+    for record in settled:
+        notes = getattr(record, "notes", "") or ""
+        market_id = getattr(record, "market_id", "") or ""
+        realized = getattr(record, "realized_pnl_usd", None)
+        realized_f = float(realized) if isinstance(realized, (int, float)) else 0.0
+        market_outcome = getattr(record, "market_outcome", None)
+        reason = normalize_exit_reason(market_outcome, realized_f)
+        exit_mix[reason] = exit_mix.get(reason, 0) + 1
+        closed_positions.append(
+            {
+                "title": clean_title(notes=notes, market_id=market_id),
+                "side": getattr(record, "side", "") or "",
+                "realized_pnl_usd": realized_f,
+                "market_outcome": market_outcome,
+                "reason": reason,
+                "exit_ts_utc": getattr(record, "exit_ts_utc", None),
+            }
+        )
+
+    # Exit feed: newest first.
+    closed_positions.sort(key=lambda row: _exit_ts_key(row["exit_ts_utc"]), reverse=True)
+
+    # --- Equity curve: realized track record, accumulated oldest -> newest. ---
+    settled_asc = sorted(
+        settled, key=lambda r: _exit_ts_key(getattr(r, "exit_ts_utc", None))
+    )
+    equity_curve: List[Dict[str, Any]] = [
+        {"t": "start", "equity": float(bankroll_usd)}
+    ]
+    running = float(bankroll_usd)
+    for record in settled_asc:
+        realized = getattr(record, "realized_pnl_usd", None)
+        running += float(realized) if isinstance(realized, (int, float)) else 0.0
+        equity_curve.append(
+            {"t": getattr(record, "exit_ts_utc", None), "equity": running}
+        )
+
+    return {
+        "summary": summary,
+        "open_positions": open_positions,
+        "closed_positions": closed_positions,
+        "exit_mix": exit_mix,
+        "equity_curve": equity_curve,
+    }

--- a/src/dashboard/state.py
+++ b/src/dashboard/state.py
@@ -37,7 +37,11 @@ if _SRC_DIR not in sys.path:
     sys.path.insert(0, _SRC_DIR)
 
 from portfolio_reporter import DEFAULT_BANKROLL_USD, build_report  # noqa: E402
-from state.pnl_ledger import PnlLedger, TradeRecord  # noqa: E402
+from state.pnl_ledger import (  # noqa: E402
+    PnlLedger,
+    TradeRecord,
+    dedupe_open_positions,
+)
 
 __all__ = ["build_state", "parse_confidence", "clean_title", "normalize_exit_reason"]
 
@@ -131,12 +135,18 @@ def build_state(
     """
     report = build_report(ledger, price_fn=None, bankroll_usd=bankroll_usd)
 
+    # Collapse duplicate opens (same market+outcome, written by two writers racing
+    # on the ledger) to one position each — we shadow ONE unit per (market,
+    # outcome), so both the count and the cards must treat a dup as one. This is
+    # why ``n_open`` is taken from the deduped list rather than ``report``.
+    deduped_open = dedupe_open_positions(ledger.open_positions())
+
     summary = {
         "equity_usd": float(report.get("equity_usd", bankroll_usd)),
         "realized_pnl_usd": float(report.get("realized_pnl_usd", 0.0)),
         "unrealized_pnl_usd": float(report.get("unrealized_pnl_usd", 0.0)),
         "win_rate": float(report.get("win_rate", 0.0)),
-        "n_open": int(report.get("n_open", 0)),
+        "n_open": len(deduped_open),
         "n_settled": int(report.get("n_settled", 0)),
         "total_fees_usd": float(report.get("total_fees_usd", 0.0)),
         "bankroll_usd": float(bankroll_usd),
@@ -144,7 +154,7 @@ def build_state(
 
     # --- Open positions: clean title + parsed confidence (entry only, no mark) ---
     open_positions: List[Dict[str, Any]] = []
-    for record in ledger.open_positions():
+    for record in deduped_open:
         notes = getattr(record, "notes", "") or ""
         market_id = getattr(record, "market_id", "") or ""
         entry_price = getattr(record, "entry_price", None)

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -1,0 +1,548 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>SHADOW · Whale-Follow Dashboard</title>
+<style>
+  :root {
+    --bg:        #0b0e14;
+    --bg-2:      #121722;
+    --panel:     #161c28;
+    --panel-2:   #1c2433;
+    --line:      #232c3d;
+    --text:      #e6ebf3;
+    --muted:     #8a97ad;
+    --faint:     #5a6679;
+    --green:     #2ee6a6;
+    --green-dim: #1f9c74;
+    --red:       #ff5d6c;
+    --amber:     #ffb454;
+    --teal:      #3ad6c8;
+    --orange:    #ff8a3d;
+    --grey:      #6b7588;
+    --accent:    #6ea8ff;
+    --shadow:    0 8px 30px rgba(0,0,0,.35);
+    --radius:    14px;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    background:
+      radial-gradient(1200px 600px at 80% -10%, #15203a 0%, transparent 55%),
+      radial-gradient(900px 500px at -10% 0%, #161227 0%, transparent 50%),
+      var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    min-height: 100vh;
+    padding: 22px clamp(14px, 3vw, 40px) 60px;
+  }
+  .mono {
+    font-family: "SF Mono", "JetBrains Mono", "Fira Code", ui-monospace, Menlo, Consolas, monospace;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: -0.2px;
+  }
+
+  /* ---------- Header ---------- */
+  header {
+    display: flex; align-items: center; justify-content: space-between;
+    flex-wrap: wrap; gap: 12px; margin-bottom: 22px;
+  }
+  .brand { display: flex; align-items: center; gap: 14px; }
+  .brand h1 {
+    font-size: 19px; margin: 0; font-weight: 650; letter-spacing: .3px;
+  }
+  .brand .sub { color: var(--muted); font-size: 12.5px; margin-top: 2px; }
+  .shadow-badge {
+    display: inline-flex; align-items: center; gap: 7px;
+    background: linear-gradient(180deg, #2a1d14, #241813);
+    color: var(--amber); border: 1px solid #4a3320;
+    padding: 7px 13px; border-radius: 999px; font-size: 12px; font-weight: 600;
+    letter-spacing: .4px;
+  }
+  .shadow-badge .dot {
+    width: 8px; height: 8px; border-radius: 50%; background: var(--amber);
+    box-shadow: 0 0 0 0 rgba(255,180,84,.7); animation: pulse 2.2s infinite;
+  }
+  @keyframes pulse {
+    0%   { box-shadow: 0 0 0 0 rgba(255,180,84,.6); }
+    70%  { box-shadow: 0 0 0 9px rgba(255,180,84,0); }
+    100% { box-shadow: 0 0 0 0 rgba(255,180,84,0); }
+  }
+  .updated { color: var(--faint); font-size: 12px; }
+  .updated b { color: var(--muted); font-weight: 600; }
+
+  /* ---------- KPI row ---------- */
+  .kpis {
+    display: grid; gap: 14px; margin-bottom: 18px;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+  .kpi {
+    background: linear-gradient(180deg, var(--panel), var(--bg-2));
+    border: 1px solid var(--line); border-radius: var(--radius);
+    padding: 16px 18px; box-shadow: var(--shadow); position: relative; overflow: hidden;
+  }
+  .kpi .label { color: var(--muted); font-size: 12px; font-weight: 600; letter-spacing: .5px; text-transform: uppercase; }
+  .kpi .value { font-size: 28px; font-weight: 680; margin-top: 8px; transition: color .4s ease; }
+  .kpi .meta { color: var(--faint); font-size: 12px; margin-top: 4px; }
+  .pos { color: var(--green); }
+  .neg { color: var(--red); }
+  .kpi.flash::after {
+    content: ""; position: absolute; inset: 0; border-radius: var(--radius);
+    background: var(--accent); opacity: .14; animation: flashfade .8s ease forwards;
+    pointer-events: none;
+  }
+  @keyframes flashfade { from { opacity: .18; } to { opacity: 0; } }
+
+  /* ---------- Layout ---------- */
+  .grid {
+    display: grid; gap: 16px;
+    grid-template-columns: 1.55fr 1fr;
+  }
+  @media (max-width: 920px) { .grid { grid-template-columns: 1fr; } }
+
+  .panel {
+    background: linear-gradient(180deg, var(--panel), var(--bg-2));
+    border: 1px solid var(--line); border-radius: var(--radius);
+    box-shadow: var(--shadow); padding: 16px 18px; min-width: 0;
+  }
+  .panel h2 {
+    font-size: 13px; text-transform: uppercase; letter-spacing: .6px;
+    color: var(--muted); margin: 0 0 12px; font-weight: 650;
+    display: flex; align-items: center; justify-content: space-between;
+  }
+  .panel h2 .count {
+    color: var(--faint); font-weight: 600; font-size: 12px;
+    background: var(--panel-2); border: 1px solid var(--line);
+    padding: 2px 8px; border-radius: 999px;
+  }
+
+  /* ---------- Equity chart ---------- */
+  #chartWrap { position: relative; }
+  canvas { width: 100%; display: block; }
+  .chart-empty {
+    color: var(--faint); font-size: 13px; text-align: center; padding: 40px 0;
+  }
+
+  /* ---------- Open position cards ---------- */
+  .cards { display: grid; gap: 10px; grid-template-columns: repeat(auto-fill, minmax(220px,1fr)); }
+  .card {
+    background: var(--panel-2); border: 1px solid var(--line); border-radius: 11px;
+    padding: 12px 13px; animation: fadein .5s ease; min-width: 0;
+  }
+  @keyframes fadein { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
+  .card .title { font-size: 13.5px; font-weight: 620; word-break: break-word; }
+  .card .row2 { display: flex; align-items: center; justify-content: space-between; margin-top: 9px; gap: 8px; }
+  .card .side { color: var(--muted); font-size: 12px; max-width: 60%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .card .entry { color: var(--text); font-size: 12.5px; }
+  .pill {
+    display: inline-block; font-size: 11px; font-weight: 700; letter-spacing: .3px;
+    padding: 3px 9px; border-radius: 999px; margin-top: 10px; text-transform: uppercase;
+  }
+  .pill.low    { background: #2a2f3a; color: var(--grey);  border: 1px solid #39414f; }
+  .pill.medium { background: #2e2410; color: var(--amber); border: 1px solid #4a3a18; }
+  .pill.high   { background: #0f2c22; color: var(--green); border: 1px solid #1c4d3c; }
+  .pill.none   { background: #232a36; color: var(--faint); border: 1px solid var(--line); }
+
+  /* ---------- Exit feed ---------- */
+  .feed { display: flex; flex-direction: column; gap: 8px; max-height: 360px; overflow-y: auto; padding-right: 4px; }
+  .feed-item {
+    display: flex; align-items: center; gap: 10px;
+    background: var(--panel-2); border: 1px solid var(--line); border-radius: 10px;
+    padding: 9px 11px; animation: slidein .45s ease;
+  }
+  @keyframes slidein { from { opacity: 0; transform: translateX(14px); } to { opacity: 1; transform: none; } }
+  .chip {
+    font-size: 10.5px; font-weight: 800; letter-spacing: .4px; padding: 3px 8px;
+    border-radius: 6px; white-space: nowrap; text-transform: uppercase;
+  }
+  .chip.won  { background: #0f2c22; color: var(--green); }
+  .chip.lost { background: #2c1318; color: var(--red); }
+  .chip.take_profit { background: #0f2a2a; color: var(--teal); }
+  .chip.stop_loss   { background: #2c1d10; color: var(--orange); }
+  .feed-item .fi-title { flex: 1; font-size: 13px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .feed-item .fi-pnl { font-weight: 700; font-size: 13px; }
+
+  /* ---------- Exit mix bars ---------- */
+  .mix { display: flex; flex-direction: column; gap: 9px; }
+  .mix-row { display: grid; grid-template-columns: 92px 1fr 34px; align-items: center; gap: 10px; }
+  .mix-row .name { font-size: 12px; color: var(--muted); text-transform: capitalize; }
+  .mix-row .track { height: 10px; background: var(--panel-2); border-radius: 6px; overflow: hidden; border: 1px solid var(--line); }
+  .mix-row .fill { height: 100%; border-radius: 6px; width: 0; transition: width .6s cubic-bezier(.2,.7,.3,1); }
+  .mix-row .num { font-size: 12.5px; color: var(--text); text-align: right; }
+  .fill.won  { background: linear-gradient(90deg, var(--green-dim), var(--green)); }
+  .fill.lost { background: var(--red); }
+  .fill.take_profit { background: var(--teal); }
+  .fill.stop_loss   { background: var(--orange); }
+  .fill.other { background: var(--accent); }
+
+  .empty { color: var(--faint); font-size: 13px; padding: 14px 2px; }
+  .stack { display: flex; flex-direction: column; gap: 16px; }
+
+  ::-webkit-scrollbar { width: 9px; height: 9px; }
+  ::-webkit-scrollbar-thumb { background: #2a3344; border-radius: 8px; }
+  ::-webkit-scrollbar-track { background: transparent; }
+</style>
+</head>
+<body>
+  <header>
+    <div class="brand">
+      <div>
+        <h1>Whale-Follow <span style="color:var(--accent)">SHADOW</span></h1>
+        <div class="sub">Read-only realized track record · polls every 4s</div>
+      </div>
+    </div>
+    <div style="display:flex; align-items:center; gap:16px;">
+      <span class="shadow-badge"><span class="dot"></span>SHADOW — no real money</span>
+      <span class="updated">updated <b id="updated">—</b></span>
+    </div>
+  </header>
+
+  <section class="kpis" id="kpis">
+    <div class="kpi" id="kpi-equity">
+      <div class="label">Equity</div>
+      <div class="value mono" id="v-equity">$—</div>
+      <div class="meta" id="m-equity">bankroll $—</div>
+    </div>
+    <div class="kpi" id="kpi-realized">
+      <div class="label">Realized P/L</div>
+      <div class="value mono" id="v-realized">$—</div>
+      <div class="meta" id="m-realized">net of fees</div>
+    </div>
+    <div class="kpi" id="kpi-winrate">
+      <div class="label">Win rate</div>
+      <div class="value mono" id="v-winrate">—%</div>
+      <div class="meta" id="m-winrate">of settled</div>
+    </div>
+    <div class="kpi" id="kpi-counts">
+      <div class="label">Open / Settled</div>
+      <div class="value mono" id="v-counts">— / —</div>
+      <div class="meta" id="m-counts">fees $—</div>
+    </div>
+  </section>
+
+  <div class="grid">
+    <div class="stack">
+      <div class="panel" id="chartPanel">
+        <h2>Realized equity <span class="count mono" id="eq-last">$—</span></h2>
+        <div id="chartWrap">
+          <canvas id="equity" height="260"></canvas>
+          <div class="chart-empty" id="chart-empty" style="display:none">No settled trades yet — the equity curve appears once positions resolve.</div>
+        </div>
+      </div>
+
+      <div class="panel">
+        <h2>Open positions <span class="count" id="open-count">0</span></h2>
+        <div class="cards" id="open-cards"></div>
+        <div class="empty" id="open-empty" style="display:none">No open positions.</div>
+      </div>
+    </div>
+
+    <div class="stack">
+      <div class="panel">
+        <h2>Exit feed <span class="count" id="feed-count">0</span></h2>
+        <div class="feed" id="feed"></div>
+        <div class="empty" id="feed-empty" style="display:none">No closed positions yet.</div>
+      </div>
+
+      <div class="panel">
+        <h2>Exit mix</h2>
+        <div class="mix" id="mix"></div>
+        <div class="empty" id="mix-empty" style="display:none">Nothing settled yet.</div>
+      </div>
+    </div>
+  </div>
+
+<script>
+"use strict";
+
+const POLL_MS = 4000;
+
+// ---- formatting helpers ----
+const fmtUsd = (v, signed) => {
+  if (v === null || v === undefined || Number.isNaN(v)) return "$—";
+  const s = (signed && v >= 0) ? "+" : (v < 0 ? "-" : "");
+  return s + "$" + Math.abs(v).toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2});
+};
+const fmtPct = (v) => (v === null || v === undefined || Number.isNaN(v)) ? "—%" : (v * 100).toFixed(1) + "%";
+const clsSign = (v) => v >= 0 ? "pos" : "neg";
+const esc = (s) => String(s == null ? "" : s).replace(/[&<>"']/g, c => (
+  {"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c]
+));
+const shortTime = (iso) => {
+  if (!iso || iso === "start") return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return String(iso);
+  return d.toLocaleString(undefined, {month:"short", day:"numeric", hour:"2-digit", minute:"2-digit"});
+};
+
+// ---- animated count-up for the equity KPI ----
+const animState = {};
+function animateNumber(key, el, target, render) {
+  const prev = animState[key];
+  if (prev === undefined) { animState[key] = target; el.textContent = render(target); return; }
+  if (prev === target) { el.textContent = render(target); return; }
+  const from = prev, to = target, start = performance.now(), dur = 650;
+  function step(now) {
+    const t = Math.min(1, (now - start) / dur);
+    const eased = 1 - Math.pow(1 - t, 3);
+    const cur = from + (to - from) * eased;
+    el.textContent = render(cur);
+    if (t < 1) requestAnimationFrame(step); else animState[key] = to;
+  }
+  animState[key] = to;
+  requestAnimationFrame(step);
+}
+
+function flash(id) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.classList.remove("flash"); void el.offsetWidth; el.classList.add("flash");
+}
+
+// ---- KPI render ----
+let lastSummaryKey = null;
+function renderKpis(s) {
+  const eqEl = document.getElementById("v-equity");
+  animateNumber("equity", eqEl, s.equity_usd, (v) => fmtUsd(v, false));
+  document.getElementById("m-equity").textContent = "bankroll " + fmtUsd(s.bankroll_usd, false);
+
+  const rl = document.getElementById("v-realized");
+  animateNumber("realized", rl, s.realized_pnl_usd, (v) => fmtUsd(v, true));
+  rl.className = "value mono " + clsSign(s.realized_pnl_usd);
+
+  const wr = document.getElementById("v-winrate");
+  animateNumber("winrate", wr, s.win_rate, (v) => (v * 100).toFixed(1) + "%");
+
+  document.getElementById("v-counts").textContent = s.n_open + " / " + s.n_settled;
+  document.getElementById("m-counts").textContent = "fees " + fmtUsd(s.total_fees_usd, false);
+
+  const key = JSON.stringify([s.equity_usd, s.realized_pnl_usd, s.n_open, s.n_settled]);
+  if (lastSummaryKey !== null && key !== lastSummaryKey) {
+    flash("kpi-equity"); flash("kpi-realized"); flash("kpi-counts");
+  }
+  lastSummaryKey = key;
+}
+
+// ---- hand-rolled canvas line chart with draw animation ----
+const canvas = document.getElementById("equity");
+const ctx = canvas.getContext("2d");
+let chartAnim = null;
+let lastCurveKey = null;
+
+function drawChart(curve, progress) {
+  const dpr = window.devicePixelRatio || 1;
+  const cssW = canvas.clientWidth || 600;
+  const cssH = 260;
+  canvas.width = cssW * dpr; canvas.height = cssH * dpr;
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  ctx.clearRect(0, 0, cssW, cssH);
+
+  if (!curve || curve.length < 2) return;
+
+  const padL = 56, padR = 14, padT = 14, padB = 26;
+  const w = cssW - padL - padR, h = cssH - padT - padB;
+  const ys = curve.map(p => p.equity);
+  let min = Math.min(...ys), max = Math.max(...ys);
+  if (min === max) { min -= 1; max += 1; }
+  const span = max - min;
+  min -= span * 0.08; max += span * 0.08;
+
+  const x = (i) => padL + (w * i) / (curve.length - 1);
+  const y = (v) => padT + h - (h * (v - min)) / (max - min);
+
+  // gridlines + y labels
+  ctx.strokeStyle = "#1e2735"; ctx.lineWidth = 1;
+  ctx.fillStyle = "#5a6679"; ctx.font = "11px ui-monospace, monospace"; ctx.textAlign = "right";
+  const rows = 4;
+  for (let r = 0; r <= rows; r++) {
+    const v = min + ((max - min) * r) / rows;
+    const yy = y(v);
+    ctx.beginPath(); ctx.moveTo(padL, yy); ctx.lineTo(cssW - padR, yy); ctx.stroke();
+    ctx.fillText("$" + v.toFixed(0), padL - 8, yy + 3);
+  }
+
+  // baseline (bankroll = first point) as a dashed reference
+  const base = curve[0].equity;
+  ctx.save();
+  ctx.setLineDash([4, 4]); ctx.strokeStyle = "#33405a"; ctx.beginPath();
+  ctx.moveTo(padL, y(base)); ctx.lineTo(cssW - padR, y(base)); ctx.stroke();
+  ctx.restore();
+
+  // how many segments to draw (animation)
+  const total = curve.length - 1;
+  const shown = Math.max(1, Math.floor(total * progress));
+  const frac = (total * progress) - shown;
+
+  const last = curve[curve.length - 1].equity;
+  const lineColor = last >= base ? "#2ee6a6" : "#ff5d6c";
+
+  // area fill under the (drawn portion of the) line
+  ctx.beginPath();
+  ctx.moveTo(x(0), y(curve[0].equity));
+  for (let i = 1; i <= shown; i++) ctx.lineTo(x(i), y(curve[i].equity));
+  let endX = x(shown), endY = y(curve[shown] ? curve[shown].equity : curve[shown - 1].equity);
+  if (frac > 0 && shown < total) {
+    const a = curve[shown], b = curve[shown + 1];
+    endX = x(shown) + (x(shown + 1) - x(shown)) * frac;
+    endY = y(a.equity + (b.equity - a.equity) * frac);
+    ctx.lineTo(endX, endY);
+  }
+  const grad = ctx.createLinearGradient(0, padT, 0, padT + h);
+  grad.addColorStop(0, last >= base ? "rgba(46,230,166,.22)" : "rgba(255,93,108,.22)");
+  grad.addColorStop(1, "rgba(0,0,0,0)");
+  ctx.lineTo(endX, padT + h); ctx.lineTo(x(0), padT + h); ctx.closePath();
+  ctx.fillStyle = grad; ctx.fill();
+
+  // the line itself
+  ctx.beginPath();
+  ctx.moveTo(x(0), y(curve[0].equity));
+  for (let i = 1; i <= shown; i++) ctx.lineTo(x(i), y(curve[i].equity));
+  if (frac > 0 && shown < total) ctx.lineTo(endX, endY);
+  ctx.strokeStyle = lineColor; ctx.lineWidth = 2.2; ctx.lineJoin = "round";
+  ctx.shadowColor = lineColor; ctx.shadowBlur = 8; ctx.stroke(); ctx.shadowBlur = 0;
+
+  // last-value dot + label (only once fully drawn)
+  if (progress >= 1) {
+    ctx.beginPath(); ctx.arc(x(total), y(last), 3.4, 0, Math.PI * 2);
+    ctx.fillStyle = lineColor; ctx.fill();
+    ctx.fillStyle = "#e6ebf3"; ctx.textAlign = "right"; ctx.font = "12px ui-monospace, monospace";
+    const lbl = "$" + last.toFixed(2);
+    const ly = Math.min(Math.max(y(last) - 8, padT + 10), padT + h - 4);
+    ctx.fillText(lbl, cssW - padR, ly);
+  }
+}
+
+function animateChart(curve) {
+  if (chartAnim) cancelAnimationFrame(chartAnim);
+  const start = performance.now(), dur = 750;
+  function step(now) {
+    const p = Math.min(1, (now - start) / dur);
+    drawChart(curve, p);
+    if (p < 1) chartAnim = requestAnimationFrame(step); else chartAnim = null;
+  }
+  chartAnim = requestAnimationFrame(step);
+}
+
+function renderChart(curve) {
+  const empty = document.getElementById("chart-empty");
+  const lastEl = document.getElementById("eq-last");
+  if (!curve || curve.length < 2) {
+    empty.style.display = "block"; canvas.style.display = "none";
+    lastEl.textContent = curve && curve.length ? fmtUsd(curve[curve.length - 1].equity, false) : "$—";
+    return;
+  }
+  empty.style.display = "none"; canvas.style.display = "block";
+  lastEl.textContent = fmtUsd(curve[curve.length - 1].equity, false);
+  const key = JSON.stringify(curve.map(p => [p.t, Math.round(p.equity * 100)]));
+  if (key !== lastCurveKey) { animateChart(curve); lastCurveKey = key; }
+  else drawChart(curve, 1);
+}
+
+// ---- open positions ----
+function confClass(c) {
+  if (!c || !c.label) return "none";
+  if (["low","medium","high"].includes(c.label)) return c.label;
+  return "none";
+}
+function renderOpen(list) {
+  const wrap = document.getElementById("open-cards");
+  const empty = document.getElementById("open-empty");
+  document.getElementById("open-count").textContent = list.length;
+  if (!list.length) { wrap.innerHTML = ""; empty.style.display = "block"; return; }
+  empty.style.display = "none";
+  wrap.innerHTML = list.map(p => {
+    const c = p.confidence;
+    const cls = confClass(c);
+    const pillText = c ? (c.label + " · " + Number(c.score).toFixed(2)) : "no conf";
+    const entry = (p.entry_price === null || p.entry_price === undefined)
+      ? "—" : "$" + Number(p.entry_price).toFixed(3);
+    return `<div class="card">
+      <div class="title">${esc(p.title)}</div>
+      <div class="row2">
+        <span class="side">${esc(p.side)}</span>
+        <span class="entry mono">entry ${entry}</span>
+      </div>
+      <span class="pill ${cls}">${esc(pillText)}</span>
+    </div>`;
+  }).join("");
+}
+
+// ---- exit feed ----
+function chipClass(reason) {
+  if (["won","lost","take_profit","stop_loss"].includes(reason)) return reason;
+  return "won";
+}
+function chipText(reason) {
+  return { won:"WON", lost:"LOST", take_profit:"TAKE-PROFIT", stop_loss:"STOP-LOSS" }[reason]
+    || String(reason).toUpperCase();
+}
+function renderFeed(list) {
+  const wrap = document.getElementById("feed");
+  const empty = document.getElementById("feed-empty");
+  document.getElementById("feed-count").textContent = list.length;
+  if (!list.length) { wrap.innerHTML = ""; empty.style.display = "block"; return; }
+  empty.style.display = "none";
+  wrap.innerHTML = list.map(p => {
+    const reason = p.reason || "won";
+    const pnl = Number(p.realized_pnl_usd || 0);
+    return `<div class="feed-item">
+      <span class="chip ${chipClass(reason)}">${chipText(reason)}</span>
+      <span class="fi-title" title="${esc(p.title)} · ${shortTime(p.exit_ts_utc)}">${esc(p.title)}</span>
+      <span class="fi-pnl mono ${clsSign(pnl)}">${fmtUsd(pnl, true)}</span>
+    </div>`;
+  }).join("");
+}
+
+// ---- exit mix ----
+const MIX_ORDER = ["won","take_profit","lost","stop_loss"];
+function renderMix(mix) {
+  const wrap = document.getElementById("mix");
+  const empty = document.getElementById("mix-empty");
+  const keys = Object.keys(mix || {});
+  if (!keys.length) { wrap.innerHTML = ""; empty.style.display = "block"; return; }
+  empty.style.display = "none";
+  const ordered = MIX_ORDER.filter(k => k in mix).concat(keys.filter(k => !MIX_ORDER.includes(k)));
+  const maxV = Math.max(...ordered.map(k => mix[k]), 1);
+  wrap.innerHTML = ordered.map(k => {
+    const v = mix[k];
+    const pct = (v / maxV) * 100;
+    const fillCls = ["won","lost","take_profit","stop_loss"].includes(k) ? k : "other";
+    const name = k.replace(/_/g, " ");
+    return `<div class="mix-row">
+      <span class="name">${esc(name)}</span>
+      <span class="track"><span class="fill ${fillCls}" data-w="${pct}"></span></span>
+      <span class="num mono">${v}</span>
+    </div>`;
+  }).join("");
+  // animate widths after layout
+  requestAnimationFrame(() => {
+    wrap.querySelectorAll(".fill").forEach(el => { el.style.width = el.getAttribute("data-w") + "%"; });
+  });
+}
+
+// ---- poll loop ----
+async function tick() {
+  try {
+    const res = await fetch("/api/state", { cache: "no-store" });
+    if (!res.ok) throw new Error("HTTP " + res.status);
+    const data = await res.json();
+    renderKpis(data.summary || {});
+    renderChart(data.equity_curve || []);
+    renderOpen(data.open_positions || []);
+    renderFeed(data.closed_positions || []);
+    renderMix(data.exit_mix || {});
+    document.getElementById("updated").textContent = new Date().toLocaleTimeString();
+  } catch (e) {
+    document.getElementById("updated").textContent = "error: " + e.message;
+  }
+}
+
+window.addEventListener("resize", () => { if (lastCurveKey) { try { drawChart(JSON.parse("[]"), 1); } catch(_){} } });
+window.addEventListener("resize", () => tick());
+tick();
+setInterval(tick, POLL_MS);
+</script>
+</body>
+</html>

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -89,7 +89,7 @@
 
   /* ---------- KPI row ---------- */
   .kpis {
-    display: grid; gap: 14px; margin-bottom: 18px;
+    display: grid; gap: 16px; margin-bottom: 18px;
     grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
   }
   .kpi {
@@ -151,7 +151,7 @@
   }
 
   /* ---------- Open position cards ---------- */
-  .cards { display: grid; gap: 11px; grid-template-columns: repeat(auto-fill, minmax(230px,1fr)); }
+  .cards { display: grid; gap: 12px; grid-template-columns: repeat(auto-fill, minmax(230px,1fr)); }
   .card {
     background: var(--surface-2); border: 1px solid var(--border); border-radius: 12px;
     padding: 13px 14px; box-shadow: var(--shadow-card); animation: fadein .45s ease; min-width: 0;
@@ -185,13 +185,14 @@
   .chip {
     font-size: 10px; font-weight: 700; letter-spacing: .5px; padding: 4px 8px;
     border-radius: 6px; white-space: nowrap; text-transform: uppercase;
+    min-width: 84px; text-align: center; flex: none;
   }
   .chip.won  { background: rgba(34,216,143,.15); color: var(--green); }
   .chip.lost { background: rgba(244,81,95,.15);  color: var(--red); }
   .chip.take_profit { background: rgba(45,212,191,.15); color: var(--teal); }
   .chip.stop_loss   { background: rgba(251,146,60,.15); color: var(--orange); }
   .feed-item .fi-title { flex: 1; font-size: 13px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .feed-item .fi-pnl { font-weight: 600; font-size: 13px; }
+  .feed-item .fi-pnl { font-weight: 600; font-size: 13px; min-width: 78px; text-align: right; flex: none; }
 
   /* ---------- Exit mix bars ---------- */
   .mix { display: flex; flex-direction: column; gap: 10px; }

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -4,45 +4,58 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>SHADOW · Whale-Follow Dashboard</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600;700&family=Fira+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
 <style>
   :root {
-    --bg:        #0b0e14;
-    --bg-2:      #121722;
-    --panel:     #161c28;
-    --panel-2:   #1c2433;
-    --line:      #232c3d;
-    --text:      #e6ebf3;
-    --muted:     #8a97ad;
-    --faint:     #5a6679;
-    --green:     #2ee6a6;
-    --green-dim: #1f9c74;
-    --red:       #ff5d6c;
-    --amber:     #ffb454;
-    --teal:      #3ad6c8;
-    --orange:    #ff8a3d;
-    --grey:      #6b7588;
-    --accent:    #6ea8ff;
-    --shadow:    0 8px 30px rgba(0,0,0,.35);
-    --radius:    14px;
+    /* Dark Mode (OLED) — deep midnight surfaces, elevated cards */
+    --bg:          #0b0f1a;
+    --bg-grad-1:   #14213d;
+    --bg-grad-2:   #1a1430;
+    --surface:     #161d2e;   /* panels */
+    --surface-2:   #1e2940;   /* cards — clearly elevated above panels */
+    --surface-3:   #26334d;   /* hover / tracks */
+    --border:      #2e3b57;   /* visible 1px dividers */
+    --border-soft: #223049;
+    --text:        #f1f5f9;
+    --muted:       #9fb0c9;
+    --faint:       #6b7c99;
+    /* brand + semantics */
+    --brand:       #f59e0b;   /* amber — "gold trust" */
+    --brand-soft:  #fbbf24;
+    --blue:        #3b82f6;   /* data accent */
+    --green:       #22d88f;   /* wins / positive */
+    --green-dim:   #15a66b;
+    --red:         #f4515f;   /* losses / negative */
+    --teal:        #2dd4bf;   /* take-profit */
+    --orange:      #fb923c;   /* stop-loss */
+    --grey:        #64748b;   /* low confidence */
+    --shadow:      0 10px 34px rgba(0,0,0,.45);
+    --shadow-card: 0 2px 10px rgba(0,0,0,.40);
+    --radius:      14px;
+    --t-fast:      .16s;
+    --t-base:      .26s;
   }
   * { box-sizing: border-box; }
   html, body { margin: 0; padding: 0; }
   body {
     background:
-      radial-gradient(1200px 600px at 80% -10%, #15203a 0%, transparent 55%),
-      radial-gradient(900px 500px at -10% 0%, #161227 0%, transparent 50%),
+      radial-gradient(1200px 620px at 82% -12%, var(--bg-grad-1) 0%, transparent 56%),
+      radial-gradient(900px 520px at -12% -4%, var(--bg-grad-2) 0%, transparent 52%),
       var(--bg);
     color: var(--text);
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-family: "Fira Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
     -webkit-font-smoothing: antialiased;
     min-height: 100vh;
     padding: 22px clamp(14px, 3vw, 40px) 60px;
   }
   .mono {
-    font-family: "SF Mono", "JetBrains Mono", "Fira Code", ui-monospace, Menlo, Consolas, monospace;
+    font-family: "Fira Code", "SF Mono", "JetBrains Mono", ui-monospace, Menlo, Consolas, monospace;
     font-variant-numeric: tabular-nums;
-    letter-spacing: -0.2px;
+    letter-spacing: -0.3px;
   }
+  :focus-visible { outline: 2px solid var(--blue); outline-offset: 2px; border-radius: 6px; }
 
   /* ---------- Header ---------- */
   header {
@@ -51,24 +64,25 @@
   }
   .brand { display: flex; align-items: center; gap: 14px; }
   .brand h1 {
-    font-size: 19px; margin: 0; font-weight: 650; letter-spacing: .3px;
+    font-size: 20px; margin: 0; font-weight: 700; letter-spacing: .2px;
   }
-  .brand .sub { color: var(--muted); font-size: 12.5px; margin-top: 2px; }
+  .brand h1 .accent { color: var(--brand); text-shadow: 0 0 16px rgba(245,158,11,.35); }
+  .brand .sub { color: var(--muted); font-size: 12.5px; margin-top: 3px; font-weight: 400; }
   .shadow-badge {
-    display: inline-flex; align-items: center; gap: 7px;
-    background: linear-gradient(180deg, #2a1d14, #241813);
-    color: var(--amber); border: 1px solid #4a3320;
-    padding: 7px 13px; border-radius: 999px; font-size: 12px; font-weight: 600;
+    display: inline-flex; align-items: center; gap: 8px;
+    background: linear-gradient(180deg, #2c2012, #241813);
+    color: var(--brand-soft); border: 1px solid #5a3d1c;
+    padding: 7px 14px; border-radius: 999px; font-size: 12px; font-weight: 600;
     letter-spacing: .4px;
   }
   .shadow-badge .dot {
-    width: 8px; height: 8px; border-radius: 50%; background: var(--amber);
-    box-shadow: 0 0 0 0 rgba(255,180,84,.7); animation: pulse 2.2s infinite;
+    width: 8px; height: 8px; border-radius: 50%; background: var(--brand);
+    box-shadow: 0 0 0 0 rgba(245,158,11,.7); animation: pulse 2.2s infinite;
   }
   @keyframes pulse {
-    0%   { box-shadow: 0 0 0 0 rgba(255,180,84,.6); }
-    70%  { box-shadow: 0 0 0 9px rgba(255,180,84,0); }
-    100% { box-shadow: 0 0 0 0 rgba(255,180,84,0); }
+    0%   { box-shadow: 0 0 0 0 rgba(245,158,11,.6); }
+    70%  { box-shadow: 0 0 0 9px rgba(245,158,11,0); }
+    100% { box-shadow: 0 0 0 0 rgba(245,158,11,0); }
   }
   .updated { color: var(--faint); font-size: 12px; }
   .updated b { color: var(--muted); font-weight: 600; }
@@ -76,21 +90,32 @@
   /* ---------- KPI row ---------- */
   .kpis {
     display: grid; gap: 14px; margin-bottom: 18px;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
   }
   .kpi {
-    background: linear-gradient(180deg, var(--panel), var(--bg-2));
-    border: 1px solid var(--line); border-radius: var(--radius);
-    padding: 16px 18px; box-shadow: var(--shadow); position: relative; overflow: hidden;
+    background: linear-gradient(180deg, var(--surface-2), var(--surface));
+    border: 1px solid var(--border); border-radius: var(--radius);
+    padding: 16px 18px; box-shadow: var(--shadow-card); position: relative; overflow: hidden;
+    transition: border-color var(--t-base) ease, transform var(--t-base) ease;
   }
-  .kpi .label { color: var(--muted); font-size: 12px; font-weight: 600; letter-spacing: .5px; text-transform: uppercase; }
-  .kpi .value { font-size: 28px; font-weight: 680; margin-top: 8px; transition: color .4s ease; }
-  .kpi .meta { color: var(--faint); font-size: 12px; margin-top: 4px; }
+  .kpi::before {
+    content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 3px;
+    background: var(--blue); opacity: .55;
+  }
+  .kpi#kpi-equity::before   { background: var(--brand); }
+  .kpi#kpi-realized::before { background: var(--green); }
+  .kpi#kpi-winrate::before  { background: var(--blue); }
+  .kpi#kpi-counts::before   { background: var(--teal); }
+  .kpi:hover { border-color: var(--border-soft); transform: translateY(-1px); }
+  .kpi .label { color: var(--muted); font-size: 11.5px; font-weight: 600; letter-spacing: .6px; text-transform: uppercase; }
+  .kpi .value { font-size: 28px; font-weight: 600; margin-top: 8px; transition: color var(--t-base) ease; }
+  .kpi#kpi-equity .value { text-shadow: 0 0 18px rgba(245,158,11,.18); }
+  .kpi .meta { color: var(--faint); font-size: 12px; margin-top: 5px; }
   .pos { color: var(--green); }
   .neg { color: var(--red); }
   .kpi.flash::after {
     content: ""; position: absolute; inset: 0; border-radius: var(--radius);
-    background: var(--accent); opacity: .14; animation: flashfade .8s ease forwards;
+    background: var(--blue); opacity: .14; animation: flashfade .8s ease forwards;
     pointer-events: none;
   }
   @keyframes flashfade { from { opacity: .18; } to { opacity: 0; } }
@@ -103,19 +128,19 @@
   @media (max-width: 920px) { .grid { grid-template-columns: 1fr; } }
 
   .panel {
-    background: linear-gradient(180deg, var(--panel), var(--bg-2));
-    border: 1px solid var(--line); border-radius: var(--radius);
+    background: linear-gradient(180deg, var(--surface), #131a29);
+    border: 1px solid var(--border); border-radius: var(--radius);
     box-shadow: var(--shadow); padding: 16px 18px; min-width: 0;
   }
   .panel h2 {
-    font-size: 13px; text-transform: uppercase; letter-spacing: .6px;
-    color: var(--muted); margin: 0 0 12px; font-weight: 650;
+    font-size: 12.5px; text-transform: uppercase; letter-spacing: .7px;
+    color: var(--muted); margin: 0 0 13px; font-weight: 600;
     display: flex; align-items: center; justify-content: space-between;
   }
   .panel h2 .count {
-    color: var(--faint); font-weight: 600; font-size: 12px;
-    background: var(--panel-2); border: 1px solid var(--line);
-    padding: 2px 8px; border-radius: 999px;
+    color: var(--text); font-weight: 600; font-size: 12px;
+    background: var(--surface-3); border: 1px solid var(--border);
+    padding: 2px 9px; border-radius: 999px;
   }
 
   /* ---------- Equity chart ---------- */
@@ -126,70 +151,82 @@
   }
 
   /* ---------- Open position cards ---------- */
-  .cards { display: grid; gap: 10px; grid-template-columns: repeat(auto-fill, minmax(220px,1fr)); }
+  .cards { display: grid; gap: 11px; grid-template-columns: repeat(auto-fill, minmax(230px,1fr)); }
   .card {
-    background: var(--panel-2); border: 1px solid var(--line); border-radius: 11px;
-    padding: 12px 13px; animation: fadein .5s ease; min-width: 0;
+    background: var(--surface-2); border: 1px solid var(--border); border-radius: 12px;
+    padding: 13px 14px; box-shadow: var(--shadow-card); animation: fadein .45s ease; min-width: 0;
+    transition: border-color var(--t-base) ease, transform var(--t-base) ease;
   }
+  .card:hover { border-color: var(--blue); transform: translateY(-2px); }
   @keyframes fadein { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
-  .card .title { font-size: 13.5px; font-weight: 620; word-break: break-word; }
-  .card .row2 { display: flex; align-items: center; justify-content: space-between; margin-top: 9px; gap: 8px; }
-  .card .side { color: var(--muted); font-size: 12px; max-width: 60%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .card .title { font-size: 13.5px; font-weight: 600; line-height: 1.35; word-break: break-word; }
+  .card .row2 { display: flex; align-items: center; justify-content: space-between; margin-top: 10px; gap: 8px; }
+  .card .side { color: var(--muted); font-size: 12px; max-width: 58%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .card .entry { color: var(--text); font-size: 12.5px; }
   .pill {
-    display: inline-block; font-size: 11px; font-weight: 700; letter-spacing: .3px;
-    padding: 3px 9px; border-radius: 999px; margin-top: 10px; text-transform: uppercase;
+    display: inline-block; font-size: 10.5px; font-weight: 700; letter-spacing: .4px;
+    padding: 3px 10px; border-radius: 999px; margin-top: 11px; text-transform: uppercase;
   }
-  .pill.low    { background: #2a2f3a; color: var(--grey);  border: 1px solid #39414f; }
-  .pill.medium { background: #2e2410; color: var(--amber); border: 1px solid #4a3a18; }
-  .pill.high   { background: #0f2c22; color: var(--green); border: 1px solid #1c4d3c; }
-  .pill.none   { background: #232a36; color: var(--faint); border: 1px solid var(--line); }
+  .pill.low    { background: rgba(100,116,139,.16); color: #9aa7bc; border: 1px solid #3a465c; }
+  .pill.medium { background: rgba(245,158,11,.14);  color: var(--brand-soft); border: 1px solid #5a3d1c; }
+  .pill.high   { background: rgba(34,216,143,.14);  color: var(--green); border: 1px solid #1c5d44; }
+  .pill.none   { background: var(--surface-3); color: var(--faint); border: 1px solid var(--border); }
 
   /* ---------- Exit feed ---------- */
   .feed { display: flex; flex-direction: column; gap: 8px; max-height: 360px; overflow-y: auto; padding-right: 4px; }
   .feed-item {
     display: flex; align-items: center; gap: 10px;
-    background: var(--panel-2); border: 1px solid var(--line); border-radius: 10px;
-    padding: 9px 11px; animation: slidein .45s ease;
+    background: var(--surface-2); border: 1px solid var(--border); border-radius: 10px;
+    padding: 10px 12px; animation: slidein .4s ease;
+    transition: border-color var(--t-base) ease;
   }
+  .feed-item:hover { border-color: var(--border-soft); }
   @keyframes slidein { from { opacity: 0; transform: translateX(14px); } to { opacity: 1; transform: none; } }
   .chip {
-    font-size: 10.5px; font-weight: 800; letter-spacing: .4px; padding: 3px 8px;
+    font-size: 10px; font-weight: 700; letter-spacing: .5px; padding: 4px 8px;
     border-radius: 6px; white-space: nowrap; text-transform: uppercase;
   }
-  .chip.won  { background: #0f2c22; color: var(--green); }
-  .chip.lost { background: #2c1318; color: var(--red); }
-  .chip.take_profit { background: #0f2a2a; color: var(--teal); }
-  .chip.stop_loss   { background: #2c1d10; color: var(--orange); }
+  .chip.won  { background: rgba(34,216,143,.15); color: var(--green); }
+  .chip.lost { background: rgba(244,81,95,.15);  color: var(--red); }
+  .chip.take_profit { background: rgba(45,212,191,.15); color: var(--teal); }
+  .chip.stop_loss   { background: rgba(251,146,60,.15); color: var(--orange); }
   .feed-item .fi-title { flex: 1; font-size: 13px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .feed-item .fi-pnl { font-weight: 700; font-size: 13px; }
+  .feed-item .fi-pnl { font-weight: 600; font-size: 13px; }
 
   /* ---------- Exit mix bars ---------- */
-  .mix { display: flex; flex-direction: column; gap: 9px; }
-  .mix-row { display: grid; grid-template-columns: 92px 1fr 34px; align-items: center; gap: 10px; }
+  .mix { display: flex; flex-direction: column; gap: 10px; }
+  .mix-row { display: grid; grid-template-columns: 96px 1fr 34px; align-items: center; gap: 10px; }
   .mix-row .name { font-size: 12px; color: var(--muted); text-transform: capitalize; }
-  .mix-row .track { height: 10px; background: var(--panel-2); border-radius: 6px; overflow: hidden; border: 1px solid var(--line); }
+  .mix-row .track { height: 10px; background: var(--surface-3); border-radius: 6px; overflow: hidden; border: 1px solid var(--border); }
   .mix-row .fill { height: 100%; border-radius: 6px; width: 0; transition: width .6s cubic-bezier(.2,.7,.3,1); }
   .mix-row .num { font-size: 12.5px; color: var(--text); text-align: right; }
   .fill.won  { background: linear-gradient(90deg, var(--green-dim), var(--green)); }
-  .fill.lost { background: var(--red); }
-  .fill.take_profit { background: var(--teal); }
-  .fill.stop_loss   { background: var(--orange); }
-  .fill.other { background: var(--accent); }
+  .fill.lost { background: linear-gradient(90deg, #b3303c, var(--red)); }
+  .fill.take_profit { background: linear-gradient(90deg, #1a9e90, var(--teal)); }
+  .fill.stop_loss   { background: linear-gradient(90deg, #c96a23, var(--orange)); }
+  .fill.other { background: linear-gradient(90deg, #2563c0, var(--blue)); }
 
   .empty { color: var(--faint); font-size: 13px; padding: 14px 2px; }
   .stack { display: flex; flex-direction: column; gap: 16px; }
 
   ::-webkit-scrollbar { width: 9px; height: 9px; }
-  ::-webkit-scrollbar-thumb { background: #2a3344; border-radius: 8px; }
+  ::-webkit-scrollbar-thumb { background: #2f3c57; border-radius: 8px; }
+  ::-webkit-scrollbar-thumb:hover { background: #3b4a6a; }
   ::-webkit-scrollbar-track { background: transparent; }
+
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      animation-duration: .001ms !important; animation-iteration-count: 1 !important;
+      transition-duration: .001ms !important;
+    }
+  }
 </style>
 </head>
 <body>
   <header>
     <div class="brand">
       <div>
-        <h1>Whale-Follow <span style="color:var(--accent)">SHADOW</span></h1>
+        <h1>Whale-Follow <span class="accent">SHADOW</span></h1>
         <div class="sub">Read-only realized track record · polls every 4s</div>
       </div>
     </div>
@@ -258,6 +295,20 @@
 "use strict";
 
 const POLL_MS = 4000;
+const REDUCE = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+// theme tokens mirrored for canvas drawing
+const C = {
+  grid:   "#1f2940",
+  axis:   "#6b7c99",
+  base:   "#2e3b57",
+  label:  "#f1f5f9",
+  green:  "#22d88f",
+  red:    "#f4515f",
+  greenFill: "rgba(34,216,143,.20)",
+  redFill:   "rgba(244,81,95,.18)",
+};
+const CHART_FONT = "11px 'Fira Code', ui-monospace, monospace";
 
 // ---- formatting helpers ----
 const fmtUsd = (v, signed) => {
@@ -281,7 +332,7 @@ const shortTime = (iso) => {
 const animState = {};
 function animateNumber(key, el, target, render) {
   const prev = animState[key];
-  if (prev === undefined) { animState[key] = target; el.textContent = render(target); return; }
+  if (prev === undefined || REDUCE) { animState[key] = target; el.textContent = render(target); return; }
   if (prev === target) { el.textContent = render(target); return; }
   const from = prev, to = target, start = performance.now(), dur = 650;
   function step(now) {
@@ -296,6 +347,7 @@ function animateNumber(key, el, target, render) {
 }
 
 function flash(id) {
+  if (REDUCE) return;
   const el = document.getElementById(id);
   if (!el) return;
   el.classList.remove("flash"); void el.offsetWidth; el.classList.add("flash");
@@ -341,7 +393,7 @@ function drawChart(curve, progress) {
 
   if (!curve || curve.length < 2) return;
 
-  const padL = 56, padR = 14, padT = 14, padB = 26;
+  const padL = 58, padR = 16, padT = 14, padB = 26;
   const w = cssW - padL - padR, h = cssH - padT - padB;
   const ys = curve.map(p => p.equity);
   let min = Math.min(...ys), max = Math.max(...ys);
@@ -353,8 +405,8 @@ function drawChart(curve, progress) {
   const y = (v) => padT + h - (h * (v - min)) / (max - min);
 
   // gridlines + y labels
-  ctx.strokeStyle = "#1e2735"; ctx.lineWidth = 1;
-  ctx.fillStyle = "#5a6679"; ctx.font = "11px ui-monospace, monospace"; ctx.textAlign = "right";
+  ctx.strokeStyle = C.grid; ctx.lineWidth = 1;
+  ctx.fillStyle = C.axis; ctx.font = CHART_FONT; ctx.textAlign = "right";
   const rows = 4;
   for (let r = 0; r <= rows; r++) {
     const v = min + ((max - min) * r) / rows;
@@ -366,7 +418,7 @@ function drawChart(curve, progress) {
   // baseline (bankroll = first point) as a dashed reference
   const base = curve[0].equity;
   ctx.save();
-  ctx.setLineDash([4, 4]); ctx.strokeStyle = "#33405a"; ctx.beginPath();
+  ctx.setLineDash([4, 4]); ctx.strokeStyle = C.base; ctx.beginPath();
   ctx.moveTo(padL, y(base)); ctx.lineTo(cssW - padR, y(base)); ctx.stroke();
   ctx.restore();
 
@@ -376,7 +428,7 @@ function drawChart(curve, progress) {
   const frac = (total * progress) - shown;
 
   const last = curve[curve.length - 1].equity;
-  const lineColor = last >= base ? "#2ee6a6" : "#ff5d6c";
+  const lineColor = last >= base ? C.green : C.red;
 
   // area fill under the (drawn portion of the) line
   ctx.beginPath();
@@ -390,7 +442,7 @@ function drawChart(curve, progress) {
     ctx.lineTo(endX, endY);
   }
   const grad = ctx.createLinearGradient(0, padT, 0, padT + h);
-  grad.addColorStop(0, last >= base ? "rgba(46,230,166,.22)" : "rgba(255,93,108,.22)");
+  grad.addColorStop(0, last >= base ? C.greenFill : C.redFill);
   grad.addColorStop(1, "rgba(0,0,0,0)");
   ctx.lineTo(endX, padT + h); ctx.lineTo(x(0), padT + h); ctx.closePath();
   ctx.fillStyle = grad; ctx.fill();
@@ -401,13 +453,13 @@ function drawChart(curve, progress) {
   for (let i = 1; i <= shown; i++) ctx.lineTo(x(i), y(curve[i].equity));
   if (frac > 0 && shown < total) ctx.lineTo(endX, endY);
   ctx.strokeStyle = lineColor; ctx.lineWidth = 2.2; ctx.lineJoin = "round";
-  ctx.shadowColor = lineColor; ctx.shadowBlur = 8; ctx.stroke(); ctx.shadowBlur = 0;
+  ctx.shadowColor = lineColor; ctx.shadowBlur = 9; ctx.stroke(); ctx.shadowBlur = 0;
 
   // last-value dot + label (only once fully drawn)
   if (progress >= 1) {
-    ctx.beginPath(); ctx.arc(x(total), y(last), 3.4, 0, Math.PI * 2);
+    ctx.beginPath(); ctx.arc(x(total), y(last), 3.6, 0, Math.PI * 2);
     ctx.fillStyle = lineColor; ctx.fill();
-    ctx.fillStyle = "#e6ebf3"; ctx.textAlign = "right"; ctx.font = "12px ui-monospace, monospace";
+    ctx.fillStyle = C.label; ctx.textAlign = "right"; ctx.font = "12px 'Fira Code', ui-monospace, monospace";
     const lbl = "$" + last.toFixed(2);
     const ly = Math.min(Math.max(y(last) - 8, padT + 10), padT + h - 4);
     ctx.fillText(lbl, cssW - padR, ly);
@@ -415,6 +467,7 @@ function drawChart(curve, progress) {
 }
 
 function animateChart(curve) {
+  if (REDUCE) { drawChart(curve, 1); return; }
   if (chartAnim) cancelAnimationFrame(chartAnim);
   const start = performance.now(), dur = 750;
   function step(now) {
@@ -446,11 +499,17 @@ function confClass(c) {
   if (["low","medium","high"].includes(c.label)) return c.label;
   return "none";
 }
+let lastOpenKey = null;
 function renderOpen(list) {
   const wrap = document.getElementById("open-cards");
   const empty = document.getElementById("open-empty");
   document.getElementById("open-count").textContent = list.length;
-  if (!list.length) { wrap.innerHTML = ""; empty.style.display = "block"; return; }
+  if (!list.length) { wrap.innerHTML = ""; empty.style.display = "block"; lastOpenKey = "[]"; return; }
+  // Only rebuild (and re-trigger the fade-in) when the data actually changes —
+  // otherwise the cards flicker on every poll.
+  const key = JSON.stringify(list.map(p => [p.title, p.side, p.entry_price, p.confidence && p.confidence.score]));
+  if (key === lastOpenKey) { empty.style.display = "none"; return; }
+  lastOpenKey = key;
   empty.style.display = "none";
   wrap.innerHTML = list.map(p => {
     const c = p.confidence;
@@ -478,11 +537,15 @@ function chipText(reason) {
   return { won:"WON", lost:"LOST", take_profit:"TAKE-PROFIT", stop_loss:"STOP-LOSS" }[reason]
     || String(reason).toUpperCase();
 }
+let lastFeedKey = null;
 function renderFeed(list) {
   const wrap = document.getElementById("feed");
   const empty = document.getElementById("feed-empty");
   document.getElementById("feed-count").textContent = list.length;
-  if (!list.length) { wrap.innerHTML = ""; empty.style.display = "block"; return; }
+  if (!list.length) { wrap.innerHTML = ""; empty.style.display = "block"; lastFeedKey = "[]"; return; }
+  const key = JSON.stringify(list.map(p => [p.title, p.reason, p.realized_pnl_usd, p.exit_ts_utc]));
+  if (key === lastFeedKey) { empty.style.display = "none"; return; }
+  lastFeedKey = key;
   empty.style.display = "none";
   wrap.innerHTML = list.map(p => {
     const reason = p.reason || "won";
@@ -497,11 +560,15 @@ function renderFeed(list) {
 
 // ---- exit mix ----
 const MIX_ORDER = ["won","take_profit","lost","stop_loss"];
+let lastMixKey = null;
 function renderMix(mix) {
   const wrap = document.getElementById("mix");
   const empty = document.getElementById("mix-empty");
   const keys = Object.keys(mix || {});
-  if (!keys.length) { wrap.innerHTML = ""; empty.style.display = "block"; return; }
+  if (!keys.length) { wrap.innerHTML = ""; empty.style.display = "block"; lastMixKey = "{}"; return; }
+  const mixKey = JSON.stringify(mix);
+  if (mixKey === lastMixKey) { empty.style.display = "none"; return; }
+  lastMixKey = mixKey;
   empty.style.display = "none";
   const ordered = MIX_ORDER.filter(k => k in mix).concat(keys.filter(k => !MIX_ORDER.includes(k)));
   const maxV = Math.max(...ordered.map(k => mix[k]), 1);
@@ -539,7 +606,6 @@ async function tick() {
   }
 }
 
-window.addEventListener("resize", () => { if (lastCurveKey) { try { drawChart(JSON.parse("[]"), 1); } catch(_){} } });
 window.addEventListener("resize", () => tick());
 tick();
 setInterval(tick, POLL_MS);

--- a/src/exchanges/polymarket_data_api.py
+++ b/src/exchanges/polymarket_data_api.py
@@ -15,12 +15,16 @@ SCOPE — READ-ONLY, NO MONEY MOVES (Constitution: safety first):
     those are explicitly out of scope for the shadow stack.
 
 LIVE-VERIFICATION CAVEAT:
-    The three endpoints below were LIVE-VERIFIED against the production
-    data-api on 2026-05-31 (real responses probed). Polymarket can change
-    paths, query-parameter names, or response shapes without notice, so an
-    operator MUST re-confirm them before trusting this client in production.
-    The base URL is a constructor parameter (``DEFAULT_BASE_URL`` default) so
-    it can be overridden without a code change.
+    The data-api endpoints below were LIVE-VERIFIED against the production
+    data-api on 2026-05-31 (real responses probed). The profit-leaderboard
+    endpoint (``get_profit_leaderboard``) lives on a DIFFERENT host —
+    ``https://lb-api.polymarket.com`` — and was LIVE-VERIFIED on 2026-06-01;
+    only the windows ``'all'`` (all-time) and ``'1d'`` (today) are confirmed,
+    any other window string returns HTTP 400. Polymarket can change paths,
+    query-parameter names, or response shapes without notice, so an operator
+    MUST re-confirm them before trusting this client in production. Both base
+    URLs are constructor parameters (``DEFAULT_BASE_URL`` / ``DEFAULT_LB_BASE_URL``
+    defaults) so they can be overridden without a code change.
 
 Endpoints (shapes the parsers are built to, verbatim from the live probe):
 
@@ -47,6 +51,13 @@ Endpoints (shapes the parsers are built to, verbatim from the live probe):
             holders:[ {proxyWallet, asset, amount:float, outcomeIndex:int,
                        name, pseudonym, verified} ]}
 
+    GET /profit?window=<all|1d>&limit=N   (HOST: https://lb-api.polymarket.com)
+        -> JSON list of profit-leaderboard rows, descending by profit:
+           {proxyWallet, amount:float(profit USD), name, pseudonym}
+        -> ``window`` confirmed values: ``'all'`` (all-time) and ``'1d'``
+           (today). Any other window string -> HTTP 400 (surfaced as a
+           :class:`PolymarketDataAPIError`, never a crash).
+
 Hermetic by construction: all HTTP goes through an injected
 ``requests.Session`` so tests never touch the network.
 """
@@ -60,12 +71,15 @@ import requests
 
 __all__ = [
     "DEFAULT_BASE_URL",
+    "DEFAULT_LB_BASE_URL",
     "PolymarketDataAPIError",
     "PolymarketDataAPIClient",
 ]
 
 
 DEFAULT_BASE_URL = "https://data-api.polymarket.com"
+# The profit leaderboard lives on a SEPARATE host (note: lb-api, not data-api).
+DEFAULT_LB_BASE_URL = "https://lb-api.polymarket.com"
 _DEFAULT_TIMEOUT_S = 10.0
 
 
@@ -86,12 +100,15 @@ class PolymarketDataAPIClient:
     so the client is fully offline-testable: tests patch ``session.get``.
 
     Args:
-        base_url:   Override for the data-api base URL. Defaults to
-                    :data:`DEFAULT_BASE_URL`. See the module docstring's
-                    live-verification caveat.
-        session:    Injected ``requests.Session`` for tests; a fresh one is
-                    created when omitted.
-        timeout_s:  Per-request timeout in seconds (default 10s).
+        base_url:    Override for the data-api base URL. Defaults to
+                     :data:`DEFAULT_BASE_URL`. See the module docstring's
+                     live-verification caveat.
+        lb_base_url: Override for the profit-leaderboard host (a DIFFERENT
+                     service from the data-api). Defaults to
+                     :data:`DEFAULT_LB_BASE_URL`.
+        session:     Injected ``requests.Session`` for tests; a fresh one is
+                     created when omitted.
+        timeout_s:   Per-request timeout in seconds (default 10s).
     """
 
     def __init__(
@@ -99,8 +116,10 @@ class PolymarketDataAPIClient:
         base_url: str = DEFAULT_BASE_URL,
         session: Optional[requests.Session] = None,
         timeout_s: float = _DEFAULT_TIMEOUT_S,
+        lb_base_url: str = DEFAULT_LB_BASE_URL,
     ) -> None:
         self._base_url = base_url.rstrip("/")
+        self._lb_base_url = lb_base_url.rstrip("/")
         self._session: requests.Session = (
             session if session is not None else requests.Session()
         )
@@ -181,6 +200,37 @@ class PolymarketDataAPIClient:
         )
         return _as_list(payload)
 
+    def get_profit_leaderboard(
+        self,
+        window: str = "all",
+        limit: int = 100,
+    ) -> List[Dict[str, Any]]:
+        """Fetch the historical *profit* leaderboard (real winners).
+
+        Issues ``GET /profit?window=<window>&limit=N`` against the separate
+        leaderboard host (:data:`DEFAULT_LB_BASE_URL`, note: ``lb-api``, NOT the
+        ``data-api`` host the other methods use). Returns the raw list of rows,
+        descending by realized profit; each row is
+        ``{proxyWallet, amount(profit USD float), name, pseudonym}``.
+
+        ``window`` is the leaderboard horizon. Only ``'all'`` (all-time) and
+        ``'1d'`` (today) are live-verified; any other value returns HTTP 400,
+        which is wrapped in :class:`PolymarketDataAPIError` (with the window in
+        the context) rather than crashing — callers see a clear error.
+
+        Read-only: this is a pure GET of a public leaderboard. It places no
+        orders, signs nothing, and touches no wallet/web3 path.
+        """
+        params: Dict[str, Any] = {"window": window, "limit": limit}
+        payload = self._get(
+            "/profit",
+            params=params,
+            context="get_profit_leaderboard",
+            detail=window,
+            base_url=self._lb_base_url,
+        )
+        return _as_list(payload)
+
     # ------------------------------------------------------------------
     # Internal HTTP
     # ------------------------------------------------------------------
@@ -191,6 +241,7 @@ class PolymarketDataAPIClient:
         params: Optional[Dict[str, Any]] = None,
         context: str = "",
         detail: Optional[str] = None,
+        base_url: Optional[str] = None,
     ) -> Any:
         """GET ``path`` and return parsed JSON, wrapping all failures.
 
@@ -198,8 +249,12 @@ class PolymarketDataAPIClient:
         :class:`PolymarketDataAPIError` with the call context (and the user or
         market detail, where relevant) and the original exception on
         ``__cause__``.
+
+        ``base_url`` defaults to the data-api host; pass the leaderboard host
+        (:data:`DEFAULT_LB_BASE_URL`) for the ``/profit`` endpoint.
         """
-        url = f"{self._base_url}{path}"
+        root = (base_url if base_url is not None else self._base_url)
+        url = f"{root}{path}"
         where = context or path
         if detail:
             where = f"{where}({detail!r})"

--- a/src/exchanges/polymarket_market_data.py
+++ b/src/exchanges/polymarket_market_data.py
@@ -75,6 +75,7 @@ except Exception:  # pragma: no cover - only hit if fetcher is unavailable.
 __all__ = [
     "PolymarketAPIError",
     "get_order_book",
+    "get_market_resolution",
     "best_ask",
     "best_bid",
     "get_yes_no_best_asks",
@@ -170,6 +171,89 @@ def get_order_book(token_id: str, session: Optional[requests.Session] = None) ->
             f"returned a non-dict payload: {type(book).__name__}"
         )
     return book
+
+
+def get_market_resolution(
+    condition_id: str,
+    session: Optional[requests.Session] = None,
+) -> Optional[Dict[str, Any]]:
+    """Read a CLOB market's resolution status for SHADOW settlement.
+
+    Issues ``GET {CLOB_API_BASE_URL}/markets/<condition_id>`` and normalizes
+    the subset of the response settlement needs into::
+
+        {
+          "closed": bool,            # market resolved? (do NOT settle if False)
+          "tokens": [               # ordered to match outcomeIndex (0, 1, ...)
+            {"outcome": str|None, "price": float|None, "winner": bool},
+            ...
+          ],
+        }
+
+    Resolution semantics (shape live-verified 2026-06-01):
+        While a market is open the CLOB returns ``closed: false`` and the caller
+        MUST leave the position open (no look-ahead settlement). Once
+        ``closed: true``, each token in the ordered ``tokens`` list carries a
+        boolean ``winner`` and a ``price`` of exactly 0 or 1. The token list is
+        ordered to match ``outcomeIndex`` (index 0, 1, ...), the same
+        ``[YES, NO]`` convention as ``clobTokenIds``, so the converged
+        ``outcomeIndex`` indexes directly into ``tokens``.
+
+    This is intentionally a degrade-gracefully read: settlement runs unattended
+    in a loop, and one unreachable/garbled market must NOT raise. ANY failure —
+    empty ``condition_id``, network error, non-2xx HTTP, non-JSON / non-dict
+    body, or a missing ``tokens``/``closed`` field — returns ``None`` so the
+    caller simply leaves that position open and retries on the next sweep.
+
+    SHADOW-ONLY: this is a pure read — it places no order, signs nothing, and
+    touches no wallet, consistent with the rest of this module.
+
+    Args:
+        condition_id: The market ``conditionId`` (a ``0x...`` string).
+        session: Optional injected ``requests.Session`` (tests patch its
+            ``get``). A fresh session carrying the scanner User-Agent is built
+            when omitted.
+
+    Returns:
+        The normalized resolution dict, or ``None`` on any error.
+    """
+    if not condition_id:
+        return None
+
+    http = _session_with_ua(session)
+    url = f"{CLOB_API_BASE_URL}/markets/{condition_id}"
+
+    try:
+        resp = http.get(url, timeout=DEFAULT_TIMEOUT_SECONDS)
+        resp.raise_for_status()
+        payload = resp.json()
+    except (requests.RequestException, ValueError):
+        return None
+    except Exception:  # pragma: no cover - defensive: never let a read crash a sweep.
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    raw_tokens = payload.get("tokens")
+    if not isinstance(raw_tokens, (list, tuple)):
+        return None
+
+    tokens: List[Dict[str, Any]] = []
+    for raw in raw_tokens:
+        if not isinstance(raw, dict):
+            # Preserve positional ordering by index: a malformed token entry
+            # would shift outcomeIndex alignment, so bail rather than mislabel.
+            return None
+        tokens.append(
+            {
+                "outcome": raw.get("outcome"),
+                "price": _coerce_price(raw.get("price")),
+                "winner": bool(raw.get("winner")),
+            }
+        )
+
+    return {"closed": bool(payload.get("closed")), "tokens": tokens}
 
 
 def _coerce_price(value: Any) -> Optional[float]:

--- a/src/exit_backtest.py
+++ b/src/exit_backtest.py
@@ -1,0 +1,285 @@
+"""Exit-overlay backtester — find the best stop-loss / take-profit for whale-follow.
+
+The whale-follow shadow loop books a symmetric hit-rate but an asymmetric realized
+P/L: the LOSERS ride all the way to $0 (a full stake forfeit) while the WINNERS are
+capped at resolution. A stop-loss / take-profit overlay fixes that asymmetry — but
+only at thresholds that actually help on the REAL forward price paths the whales sat
+through. This module is the pure, offline half that searches that grid; the live
+read-only data collector lives in ``scripts/optimize_exits.py``.
+
+SCOPE — PURE / NO MONEY MOVES (Constitution: safety first):
+    Every function here is a pure computation over numbers the CALLER supplies. There
+    is no network, no client, no ledger, no order/sign/redeem/web3 path anywhere in
+    this module. It reads nothing and writes nothing — it just simulates what a paper
+    position WOULD have booked under a given exit overlay.
+
+No look-ahead / honest reporting:
+    :func:`simulate_exit` is handed a ``price_path`` the caller GUARANTEES is in
+    chronological order and consists ONLY of prices observed strictly AFTER entry
+    (the collector builds it from post-entry trades only). The walk makes its exit
+    decision from the path prices alone — it NEVER consults ``final_price`` (the
+    resolved outcome) until the path is exhausted with no trigger. So the overlay can
+    only "know" what was observable at each step, never the future outcome. The same
+    return-on-cost math and 200 bps fee as :mod:`exit_rules` / :mod:`shadow_settlement`
+    are used so the numbers are comparable to the shadow ledger.
+"""
+
+from __future__ import annotations
+
+from itertools import product
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+
+__all__ = [
+    "DEFAULT_FEE_BPS",
+    "RISK_ADJUSTED_WORST_FLOOR",
+    "simulate_exit",
+    "grid_search",
+]
+
+# Polymarket-style proceeds haircut on an exit/redemption: ~2% (200 bps). Kept in
+# sync with exit_rules.DEFAULT_FEE_BPS / shadow_settlement.DEFAULT_FEE_BPS so the
+# backtest's realized returns are directly comparable to the shadow ledger's.
+DEFAULT_FEE_BPS = 200.0
+
+# The "risk_adjusted" pick caps a single trade's worst loss at 60% of cost: a combo
+# is only eligible if EVERY trade's return_on_cost stayed >= this floor.
+RISK_ADJUSTED_WORST_FLOOR = -0.6
+
+
+def simulate_exit(
+    entry_price: float,
+    price_path: Sequence[float],
+    final_price: float,
+    *,
+    stop_loss_pct: Optional[float],
+    take_profit_pct: Optional[float],
+    take_profit_price: Optional[float],
+    fee_bps: float = DEFAULT_FEE_BPS,
+) -> Tuple[float, str]:
+    """Simulate one position under a stop-loss / take-profit overlay.
+
+    Walks ``price_path`` in chronological order — the caller GUARANTEES every price
+    is observed strictly AFTER entry, so there is no look-ahead — and exits at the
+    FIRST price that trips a rule (first trigger in TIME wins). At each price ``P``
+    (validated to lie in ``[0, 1]``; out-of-range prices are skipped, never acted
+    on) the return-on-cost is ``r = P / entry_price - 1`` and:
+
+      * stop-loss is checked FIRST: if ``stop_loss_pct`` is set and
+        ``r <= -abs(stop_loss_pct)`` -> EXIT at ``P``, reason ``'stop_loss'`` (cut
+        the loss before considering any upside lock — the capital-preserving
+        choice, matching :func:`exit_rules.evaluate_exit`);
+      * else take-profit: an absolute price target wins over the relative one —
+        if ``take_profit_price`` is set and ``P >= take_profit_price`` -> EXIT
+        ``'take_profit'``; elif ``take_profit_pct`` is set and
+        ``r >= take_profit_pct`` -> EXIT ``'take_profit'``.
+
+    If no rule fires across the WHOLE path, the position is held to resolution and
+    exits at ``final_price`` (``1.0`` won / ``0.0`` lost), reason ``'resolution'``.
+    ``final_price`` is consulted ONLY at this point — never during the walk.
+
+    The realized return PER $1 of cost (notional-agnostic) is::
+
+        return_on_cost = (1.0 / entry_price) * exit_price * (1 - fee_bps / 10_000) - 1.0
+
+    i.e. $1 of cost buys ``1/entry_price`` shares, each sold/redeemed at
+    ``exit_price`` net of the ``fee_bps`` haircut. An unsizable entry
+    (``entry_price <= 0``) returns ``(0.0, 'skip')`` so the caller can drop it
+    rather than fabricate a number.
+
+    Args:
+        entry_price: Dollars per outcome share paid at entry, expected in ``(0, 1]``.
+        price_path: Held outcome's prices in chronological order, ALL strictly
+            after entry (caller-guaranteed; no future leak).
+        final_price: Resolved price of the held outcome — ``1.0`` (won) or ``0.0``
+            (lost).
+        stop_loss_pct: Cut when ``r <= -abs(stop_loss_pct)`` (e.g. ``0.4`` = down
+            40%). ``None`` disables the stop.
+        take_profit_pct: Lock when ``r >= take_profit_pct`` (e.g. ``0.5`` = up 50%).
+            ``None`` disables this leg.
+        take_profit_price: Lock when ``P >= take_profit_price`` (e.g. ``0.90``).
+            Checked before ``take_profit_pct``. ``None`` disables.
+        fee_bps: Proceeds haircut in basis points (default 200 = ~2%).
+
+    Returns:
+        ``(return_on_cost, reason)`` where reason is one of ``'stop_loss'``,
+        ``'take_profit'``, ``'resolution'``, ``'skip'``.
+    """
+    if entry_price is None or entry_price <= 0:
+        return (0.0, "skip")
+
+    entry = float(entry_price)
+    sl = None if stop_loss_pct is None else abs(float(stop_loss_pct))
+
+    for raw in price_path:
+        if not isinstance(raw, (int, float)) or isinstance(raw, bool):
+            continue
+        price = float(raw)
+        if not (0.0 <= price <= 1.0):
+            continue
+
+        r = price / entry - 1.0
+
+        # Stop-loss FIRST: cap the downside before any upside lock.
+        if sl is not None and r <= -sl:
+            return (_return_on_cost(entry, price, fee_bps), "stop_loss")
+
+        # Take-profit: absolute price target takes precedence over the relative one.
+        if take_profit_price is not None and price >= float(take_profit_price):
+            return (_return_on_cost(entry, price, fee_bps), "take_profit")
+        if take_profit_pct is not None and r >= float(take_profit_pct):
+            return (_return_on_cost(entry, price, fee_bps), "take_profit")
+
+    # No trigger across the whole path -> hold to resolution.
+    return (_return_on_cost(entry, float(final_price), fee_bps), "resolution")
+
+
+def _return_on_cost(entry_price: float, exit_price: float, fee_bps: float) -> float:
+    """Realized return per $1 of cost: ``(1/entry)*exit*(1 - fee) - 1``."""
+    return (1.0 / entry_price) * exit_price * (1.0 - float(fee_bps) / 10_000.0) - 1.0
+
+
+def _aggregate_combo(
+    samples: Sequence[Dict[str, Any]],
+    *,
+    stop_loss_pct: Optional[float],
+    take_profit_pct: Optional[float],
+    take_profit_price: Optional[float],
+    fee_bps: float,
+) -> Dict[str, Any]:
+    """Run one (sl, tp_pct, tp_price) combo over all samples and aggregate.
+
+    Skips samples whose entry is unsizable (``simulate_exit`` returns reason
+    ``'skip'``) so the aggregates reflect only positions that could be sized. The
+    ``exit_mix`` counts cover only the included samples and therefore sum to ``n``.
+    """
+    returns: List[float] = []
+    exit_mix: Dict[str, int] = {}
+    for sample in samples:
+        ret, reason = simulate_exit(
+            float(sample.get("entry_price", 0.0)),
+            sample.get("price_path") or [],
+            float(sample.get("final_price", 0.0)),
+            stop_loss_pct=stop_loss_pct,
+            take_profit_pct=take_profit_pct,
+            take_profit_price=take_profit_price,
+            fee_bps=fee_bps,
+        )
+        if reason == "skip":
+            continue
+        returns.append(ret)
+        exit_mix[reason] = exit_mix.get(reason, 0) + 1
+
+    n = len(returns)
+    total = sum(returns)
+    wins = sum(1 for r in returns if r > 0)
+    return {
+        "stop_loss_pct": stop_loss_pct,
+        "take_profit_pct": take_profit_pct,
+        "take_profit_price": take_profit_price,
+        "n": n,
+        "mean_return": (total / n) if n else 0.0,
+        "total_return": total,
+        "win_rate": (wins / n) if n else 0.0,
+        "worst_return": min(returns) if returns else 0.0,
+        "exit_mix": exit_mix,
+    }
+
+
+def grid_search(
+    samples: Sequence[Dict[str, Any]],
+    *,
+    sl_values: Sequence[Optional[float]],
+    tp_pct_values: Sequence[Optional[float]],
+    tp_price_values: Sequence[Optional[float]],
+    fee_bps: float = DEFAULT_FEE_BPS,
+) -> Dict[str, Any]:
+    """Backtest every (stop_loss, take_profit_pct, take_profit_price) combo.
+
+    For EVERY combo in the cartesian product of ``sl_values`` x ``tp_pct_values`` x
+    ``tp_price_values`` (include ``None`` in each list to test "no stop" / "no TP"),
+    :func:`simulate_exit` is run over all ``samples`` and the results aggregated.
+    The BASELINE combo — all three ``None``, i.e. hold every position to resolution
+    — is always included (added explicitly if the caller's lists omit ``None``) so
+    every overlay can be compared against doing nothing.
+
+    ``samples`` is a list of ``{'entry_price', 'price_path', 'final_price'}`` dicts
+    (extra keys ignored). Each combo aggregate carries ``stop_loss_pct``,
+    ``take_profit_pct``, ``take_profit_price``, ``n``, ``mean_return``,
+    ``total_return``, ``win_rate`` (share with ``return_on_cost > 0``),
+    ``worst_return`` (the single worst trade), and ``exit_mix`` (counts by reason,
+    summing to ``n``).
+
+    Returns a dict::
+
+        {
+          "combos": [...],            # every combo, sorted by mean_return desc
+          "baseline": {...},          # the all-None hold-to-resolution combo
+          "best_by_meanret": {...},   # combos[0] (highest mean_return)
+          "risk_adjusted": {...},     # max mean_return among combos whose
+                                      # worst_return >= RISK_ADJUSTED_WORST_FLOOR
+        }
+
+    ``risk_adjusted`` caps the single-trade loss at 60% of cost
+    (:data:`RISK_ADJUSTED_WORST_FLOOR`); if no combo clears that floor it is
+    ``None``.
+    """
+    seen: set = set()
+    combos: List[Dict[str, Any]] = []
+
+    def _key(sl: Optional[float], tp_pct: Optional[float], tp_price: Optional[float]):
+        return (sl, tp_pct, tp_price)
+
+    for sl, tp_pct, tp_price in product(sl_values, tp_pct_values, tp_price_values):
+        key = _key(sl, tp_pct, tp_price)
+        if key in seen:
+            continue
+        seen.add(key)
+        combos.append(
+            _aggregate_combo(
+                samples,
+                stop_loss_pct=sl,
+                take_profit_pct=tp_pct,
+                take_profit_price=tp_price,
+                fee_bps=fee_bps,
+            )
+        )
+
+    # Guarantee the baseline (hold-to-resolution) is present for comparison even if
+    # the caller's grids omitted None on some axis.
+    baseline_key = _key(None, None, None)
+    if baseline_key not in seen:
+        seen.add(baseline_key)
+        combos.append(
+            _aggregate_combo(
+                samples,
+                stop_loss_pct=None,
+                take_profit_pct=None,
+                take_profit_price=None,
+                fee_bps=fee_bps,
+            )
+        )
+
+    combos.sort(key=lambda c: c["mean_return"], reverse=True)
+
+    baseline = next(
+        c
+        for c in combos
+        if c["stop_loss_pct"] is None
+        and c["take_profit_pct"] is None
+        and c["take_profit_price"] is None
+    )
+
+    best_by_meanret = combos[0] if combos else None
+
+    eligible = [c for c in combos if c["worst_return"] >= RISK_ADJUSTED_WORST_FLOOR]
+    # combos is already sorted by mean_return desc, so the first eligible one is the
+    # max-mean_return combo that respects the worst-loss floor.
+    risk_adjusted = eligible[0] if eligible else None
+
+    return {
+        "combos": combos,
+        "baseline": baseline,
+        "best_by_meanret": best_by_meanret,
+        "risk_adjusted": risk_adjusted,
+    }

--- a/src/exit_rules.py
+++ b/src/exit_rules.py
@@ -1,0 +1,257 @@
+"""Shadow early-exit rules — cap the loss, lock the win (SHADOW-ONLY, NO ORDERS).
+
+The whale-follow shadow loop's last live settlement batch realized -$917 over 18
+trades (9 won / 9 lost): the LOSERS rode all the way to $0 (a full -$100 stake)
+while the WINNERS were capped at resolution. That asymmetry — symmetric hit-rate,
+asymmetric realized P/L — is exactly what a stop-loss / take-profit overlay fixes.
+
+This module sweeps the OPEN ledger positions, re-prices each to the CURRENT
+market mark (via the injected ``price_fn`` — the same decision-time
+:func:`whale_follow_runner.make_whale_price_fn` re-pricer used by the portfolio
+report), and settles the ones that have hit a stop-loss or take-profit threshold
+at that current mark. A losing position is closed early at the mark instead of
+forfeiting the whole stake at $0; a winning position is locked in instead of
+risking a reversal before resolution.
+
+SCOPE — SHADOW-ONLY, NO MONEY MOVES (Constitution: safety first):
+    These rules are pure bookkeeping over the append-only ledger. They read the
+    current observable mark through ``price_fn`` and append ``settle`` events.
+    They place NO orders, sign nothing, redeem nothing on-chain, and touch no
+    wallet. The realized P/L recorded is the P/L a paper position WOULD have
+    booked by selling at the current mark — never a real fill.
+
+No look-ahead / honest reporting:
+    Exit decisions use ONLY the current observable mark (``price_fn(record)`` is
+    a decision-time re-price, NOT a future price). A position with no current
+    mark (``price_fn`` returns ``None``) or an out-of-range mark is LEFT OPEN
+    rather than settled on a guessed price. The settlement is stamped "now",
+    which is at/after the entry time, so the ledger's own no-look-ahead guard
+    (``exit_ts >= entry ts``) is satisfied.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, Optional
+
+
+__all__ = [
+    "evaluate_exit",
+    "compute_exit_pnl",
+    "apply_exit_rules",
+]
+
+# Polymarket-style proceeds haircut on an early exit: ~2% fee/slippage on the
+# gross proceeds of selling the outcome token at the current mark. Conservative
+# — it understates the realized exit P/L rather than flattering it.
+DEFAULT_FEE_BPS = 200.0
+
+
+def _utc_now_iso() -> str:
+    """Current UTC time as an ISO-8601 string (exit/settlement timestamp)."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def evaluate_exit(
+    entry_price: float,
+    current_price: Any,
+    *,
+    stop_loss_pct: Optional[float],
+    take_profit_pct: Optional[float],
+    take_profit_price: Optional[float],
+) -> Optional[str]:
+    """Decide whether an open position should exit NOW, and why.
+
+    The decision is on the return-on-cost ``r = current_price / entry_price - 1``
+    — the percentage move of the outcome token's mark since entry. It is only
+    computed when the position is markable: ``entry_price > 0`` and
+    ``current_price`` is a number in ``[0, 1]`` (Polymarket outcome prices are
+    probabilities in dollars). Anything else (unpriced entry, ``None`` mark,
+    out-of-range mark) returns ``None`` (HOLD) — we never act on a guessed price.
+
+    Stop-loss is checked FIRST so a position that is simultaneously past its
+    stop AND (somehow) past a take-profit threshold is treated as a loss to cut,
+    never as a win to lock — the conservative, capital-preserving choice.
+
+    Args:
+        entry_price:        Dollars per outcome share paid at entry, in ``(0, 1]``.
+        current_price:      The current market mark of the held outcome.
+        stop_loss_pct:      Cut the loss when ``r <= -abs(stop_loss_pct)`` (e.g.
+                            ``0.40`` exits a position down >= 40%). ``None``
+                            disables the stop.
+        take_profit_pct:    Lock the win when ``r >= take_profit_pct`` (e.g.
+                            ``0.50`` exits a position up >= 50%). ``None``
+                            disables this take-profit leg.
+        take_profit_price:  Lock the win when ``current_price >= take_profit_price``
+                            (e.g. ``0.90`` exits a near-certain winner outright).
+                            Checked BEFORE ``take_profit_pct``. ``None`` disables.
+
+    Returns:
+        ``'stop_loss'`` | ``'take_profit'`` | ``None`` (hold).
+    """
+    if entry_price is None or entry_price <= 0:
+        return None
+    if not isinstance(current_price, (int, float)) or isinstance(current_price, bool):
+        return None
+    if not (0.0 <= float(current_price) <= 1.0):
+        return None
+
+    r = float(current_price) / float(entry_price) - 1.0
+
+    # Stop-loss FIRST: cap the downside before considering any upside lock.
+    if stop_loss_pct is not None and r <= -abs(float(stop_loss_pct)):
+        return "stop_loss"
+
+    # Take-profit: an absolute price target (near-certain win) takes precedence
+    # over the relative return target.
+    if take_profit_price is not None and float(current_price) >= float(take_profit_price):
+        return "take_profit"
+    if take_profit_pct is not None and r >= float(take_profit_pct):
+        return "take_profit"
+
+    return None
+
+
+def compute_exit_pnl(
+    entry_price: float,
+    size_usd: float,
+    exit_price: float,
+    *,
+    fee_bps: float = DEFAULT_FEE_BPS,
+) -> float:
+    """Realized P/L (USD) of selling a shadow outcome-share position at a mark.
+
+    A shadow position buys ``size_usd`` of notional at ``entry_price`` dollars
+    per outcome share, so it holds ``units = size_usd / entry_price`` shares.
+    Exiting early SELLS those shares at the current ``exit_price`` mark, net of a
+    ``fee_bps`` basis-point haircut (default 200 bps = ~2%) on the gross
+    proceeds — a conservative fee/slippage allowance::
+
+        units    = size_usd / entry_price
+        proceeds = units * exit_price * (1 - fee_bps / 10_000)
+        realized = proceeds - size_usd
+
+    Because ``exit_price`` is the CURRENT mark (not $0), a losing exit recovers
+    most of the stake instead of forfeiting all of it — that is the whole point
+    of the stop-loss lever. Returns ``0.0`` when the position cannot be sized
+    (``entry_price <= 0`` or ``size_usd <= 0``). Rounded to 4 decimal places.
+
+    Args:
+        entry_price: Dollars per outcome share paid at entry, in ``(0, 1]``.
+        size_usd: USD notional staked on the position.
+        exit_price: Current market mark the shares are sold at, in ``[0, 1]``.
+        fee_bps: Haircut on the gross proceeds, in basis points.
+
+    Returns:
+        Realized P/L in USD (negative on a losing exit but > -size_usd, positive
+        on a winning exit), or ``0.0`` when unsizable.
+    """
+    if entry_price <= 0 or size_usd <= 0:
+        return 0.0
+    units = float(size_usd) / float(entry_price)
+    proceeds = units * float(exit_price) * (1.0 - float(fee_bps) / 10_000.0)
+    return round(proceeds - float(size_usd), 4)
+
+
+def apply_exit_rules(
+    ledger: Any,
+    price_fn: Callable[[Any], Optional[float]],
+    *,
+    stop_loss_pct: Optional[float],
+    take_profit_pct: Optional[float],
+    take_profit_price: Optional[float],
+    fee_bps: float = DEFAULT_FEE_BPS,
+    now_iso: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Sweep open positions and settle the ones that hit a stop / take-profit.
+
+    For each ``ledger.open_positions()`` record:
+      * re-price it to the CURRENT mark via ``price_fn(record)`` (decision-time,
+        NOT a future price);
+      * decide the exit via :func:`evaluate_exit` on the record's
+        ``entry_price`` and that mark;
+      * if an exit fires, compute the realized P/L via :func:`compute_exit_pnl`
+        and append a ``settle`` event at the current mark with
+        ``market_outcome = "exit:<reason>"``;
+      * otherwise leave it open.
+
+    A position with no current mark (``price_fn`` returns ``None``) or one that
+    does not meet a threshold is LEFT OPEN — settlement only ever happens at a
+    real observed mark. Each position is wrapped so a ``price_fn`` / settle error
+    is logged and skipped, never aborting the sweep (one bad market must not stop
+    the others). SHADOW-ONLY: appends ledger events, places NO orders.
+
+    Args:
+        ledger: A :class:`state.pnl_ledger.PnlLedger` (or compatible) exposing
+            ``open_positions()`` and ``settle(...)``.
+        price_fn: ``callable(record) -> current mark | None`` (decision-time).
+        stop_loss_pct / take_profit_pct / take_profit_price: see
+            :func:`evaluate_exit`.
+        fee_bps: Proceeds haircut passed to :func:`compute_exit_pnl`.
+        now_iso: Exit timestamp to record (ISO-8601 UTC). Defaults to now. Must
+            be at/after each record's entry time or the ledger guard rejects it.
+
+    Returns:
+        A counts dict::
+
+            {"exited", "stop_loss", "take_profit", "still_open",
+             "realized_pnl_usd"}
+    """
+    exit_ts = now_iso or _utc_now_iso()
+    counts = {
+        "exited": 0,
+        "stop_loss": 0,
+        "take_profit": 0,
+        "still_open": 0,
+        "realized_pnl_usd": 0.0,
+    }
+
+    try:
+        open_positions = ledger.open_positions()
+    except Exception as exc:  # pragma: no cover - never let a read crash the sweep.
+        logging.warning("exit rules: open_positions() failed (%s)", exc)
+        return counts
+
+    for record in open_positions:
+        try:
+            current_price = price_fn(record)
+            reason = evaluate_exit(
+                record.entry_price,
+                current_price,
+                stop_loss_pct=stop_loss_pct,
+                take_profit_pct=take_profit_pct,
+                take_profit_price=take_profit_price,
+            )
+            if reason is None:
+                counts["still_open"] += 1
+                continue
+
+            pnl = compute_exit_pnl(
+                float(record.entry_price),
+                float(record.size),
+                float(current_price),
+                fee_bps=fee_bps,
+            )
+            ledger.settle(
+                record.trade_id,
+                exit_price=float(current_price),
+                exit_ts_utc=exit_ts,
+                market_outcome=f"exit:{reason}",
+                realized_pnl_usd=pnl,
+            )
+        except Exception as exc:  # noqa: BLE001 - one bad position must not abort the sweep.
+            logging.warning(
+                "exit rules: position %s failed (%s); leaving open.",
+                getattr(record, "trade_id", "?"),
+                exc,
+            )
+            counts["still_open"] += 1
+            continue
+
+        counts["exited"] += 1
+        counts[reason] += 1
+        counts["realized_pnl_usd"] += pnl
+
+    counts["realized_pnl_usd"] = round(counts["realized_pnl_usd"], 4)
+    return counts

--- a/src/exit_rules.py
+++ b/src/exit_rules.py
@@ -35,6 +35,11 @@ import logging
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, Optional
 
+try:  # Flat import under PYTHONPATH=src (matches the rest of the stack).
+    from state.pnl_ledger import dedupe_open_positions
+except Exception:  # pragma: no cover - alternate layout shim.
+    from src.state.pnl_ledger import dedupe_open_positions  # type: ignore
+
 
 __all__ = [
     "evaluate_exit",
@@ -212,6 +217,12 @@ def apply_exit_rules(
     except Exception as exc:  # pragma: no cover - never let a read crash the sweep.
         logging.warning("exit rules: open_positions() failed (%s)", exc)
         return counts
+
+    # One early-exit per (market, outcome): if two writers raced and wrote
+    # duplicate opens, exiting both would book the realized P/L twice. Settle the
+    # earliest and leave any duplicate untouched (hidden from the dashboard and
+    # retired by the runner's self-heal). Mirrors shadow_settlement.
+    open_positions = dedupe_open_positions(open_positions)
 
     for record in open_positions:
         try:

--- a/src/portfolio_reporter.py
+++ b/src/portfolio_reporter.py
@@ -36,9 +36,13 @@ from typing import Any, Callable, Dict, List, Optional, Sequence
 _CONFIDENCE_RE = re.compile(r"confidence=([0-9.]+ \([a-z]+\))")
 
 try:  # Flat import (PYTHONPATH=src), matching the rest of the codebase.
-    from state.pnl_ledger import PnlLedger, TradeRecord
+    from state.pnl_ledger import PnlLedger, TradeRecord, dedupe_open_positions
 except ImportError:  # pragma: no cover - fallback for package-style import.
-    from src.state.pnl_ledger import PnlLedger, TradeRecord  # type: ignore
+    from src.state.pnl_ledger import (  # type: ignore
+        PnlLedger,
+        TradeRecord,
+        dedupe_open_positions,
+    )
 
 __all__ = [
     "DEFAULT_BANKROLL_USD",
@@ -150,10 +154,15 @@ def build_report(
     summary = ledger.summary()
     realized_pnl = float(summary.get("total_realized_pnl_usd", 0.0))
 
+    # Mark ONE position per (market, outcome): a duplicate open (two writers
+    # racing on the ledger) would otherwise inflate unrealized P/L and equity.
+    # Mirrors the dedup in shadow_settlement / exit_rules / dashboard.state so the
+    # marked equity is correct on its own, not reliant on a caller running the
+    # runner's self-heal first (e.g. arb_shadow_runner reports without healing).
     open_rows: List[Dict[str, Any]] = []
     unrealized_total = 0.0
     n_pending = 0
-    for record in ledger.open_positions():
+    for record in dedupe_open_positions(ledger.open_positions()):
         price = price_fn(record) if price_fn is not None else None
         row = mark_open_position(record, price)
         if row["marked"]:
@@ -183,7 +192,7 @@ def build_report(
         "unrealized_pnl_usd": unrealized_total,
         "total_pnl_usd": realized_pnl + unrealized_total,
         "equity_usd": equity,
-        "n_open": int(summary.get("n_open", len(open_rows))),
+        "n_open": len(open_rows),  # deduped (one per market+outcome), matches marking
         "n_settled": int(summary.get("n_settled", len(settled_rows))),
         "n_pending_mark": n_pending,
         "win_rate": float(summary.get("win_rate", 0.0)),

--- a/src/shadow_settlement.py
+++ b/src/shadow_settlement.py
@@ -1,0 +1,256 @@
+"""Shadow settlement — turn the open whale-follow ledger into a TRACK RECORD.
+
+The whale-convergence shadow runner logs open ``whale_convergence`` candidates
+to the PnL ledger but never closes them, so the ledger only ever shows
+unrealized marks. This module is the missing other half: it sweeps the open
+positions, asks Polymarket whether each position's market has RESOLVED, and —
+only for the resolved ones — settles them into the ledger with a real realized
+PnL. That converts the running shadow into a forward-validated track record the
+edge can be judged on before any capital is ever risked.
+
+SCOPE — SHADOW-ONLY, NO MONEY MOVES (Constitution: safety first):
+    Settlement is pure bookkeeping over the append-only ledger. It reads the
+    CLOB ``/markets/<conditionId>`` resolution endpoint (via an injected
+    ``resolver`` callable) and appends ``settle`` events to the ledger. It
+    places NO orders, signs nothing, redeems nothing on-chain, and touches no
+    wallet. The realized PnL it records is the PnL a paper position WOULD have
+    booked — never a real fill.
+
+No look-ahead / honest reporting:
+    A position is settled ONLY when the resolver reports ``closed: true`` for
+    its market — an open market is left open (no fabricating an outcome from a
+    not-yet-resolved book). The ledger's own settle guard additionally rejects
+    any ``exit_ts_utc`` before the entry time. When a position has no usable
+    entry price (``entry_price <= 0`` — the ``/holders`` path that records
+    ``0.0`` when no current mark is available) we CANNOT compute a realized PnL
+    honestly, so we skip it and count it ``unpriced`` rather than fabricate a
+    number.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, Optional
+
+
+__all__ = [
+    "compute_settlement_pnl",
+    "settle_resolved_positions",
+]
+
+# Pulls the ``outcomeIndex=<n>`` marker the runner writes into a record's notes.
+# Kept in sync with whale_follow_runner._OUTCOME_INDEX_RE.
+_OUTCOME_INDEX_RE = re.compile(r"outcomeIndex=(\d+)")
+
+# Polymarket charges no fee to enter/exit a position on the CLOB, but applies a
+# settlement fee (~2%, i.e. 200 bps) to the WINNING gross redemption payout. We
+# model only that: a losing position simply forfeits its stake (no fee on $0).
+DEFAULT_FEE_BPS = 200.0
+
+
+def compute_settlement_pnl(
+    entry_price: float,
+    size_usd: float,
+    won: bool,
+    *,
+    fee_bps: float = DEFAULT_FEE_BPS,
+) -> float:
+    """Realized PnL (USD) of a shadow outcome-share position at resolution.
+
+    A shadow position buys ``size_usd`` of notional at ``entry_price`` dollars
+    per outcome share, so it holds ``units = size_usd / entry_price`` shares.
+    At resolution each share redeems for $1 if the outcome WON, or $0 if it
+    lost.
+
+    Fee assumption (Polymarket): there is no fee to enter or exit a position,
+    but a settlement fee of ``fee_bps`` basis points (default 200 bps = ~2%)
+    is applied to the WINNING GROSS PAYOUT only. A losing position pays no fee —
+    it simply forfeits the stake. Hence::
+
+        won  -> units * 1.0 * (1 - fee_bps / 10_000) - size_usd
+        lost -> -size_usd
+
+    Returns ``0.0`` when the position cannot be sized — ``entry_price <= 0``
+    (the ``/holders`` unmarkable case) or ``size_usd <= 0`` — so the caller can
+    skip it rather than fabricate a realized number. Rounded to 4 decimal
+    places (sub-cent) to keep the ledger tidy.
+
+    Args:
+        entry_price: Dollars per outcome share paid at entry, in ``(0, 1]``.
+        size_usd: USD notional staked on the position.
+        won: Whether the held outcome resolved as the winner.
+        fee_bps: Settlement fee on the winning gross payout, in basis points.
+
+    Returns:
+        Realized PnL in USD (positive for a win net of fee, ``-size_usd`` for a
+        loss, ``0.0`` when unsizable).
+    """
+    if entry_price <= 0 or size_usd <= 0:
+        return 0.0
+
+    if not won:
+        return round(-float(size_usd), 4)
+
+    units = float(size_usd) / float(entry_price)
+    gross_payout = units * 1.0
+    net_payout = gross_payout * (1.0 - float(fee_bps) / 10_000.0)
+    return round(net_payout - float(size_usd), 4)
+
+
+def _utc_now_iso() -> str:
+    """Current UTC time as an ISO-8601 string (settlement/exit timestamp)."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def settle_resolved_positions(
+    ledger: Any,
+    resolver: Callable[[str], Optional[Dict[str, Any]]],
+    *,
+    fee_bps: float = DEFAULT_FEE_BPS,
+    now_iso: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Settle every open ledger position whose Polymarket market has RESOLVED.
+
+    Sweeps ``ledger.open_positions()`` and, for each, asks ``resolver`` whether
+    that position's market (``record.market_id`` = the ``conditionId``) has
+    resolved. ``resolver`` is a ``callable(market_id) -> resolution-dict | None``
+    (so tests inject a fake; production passes
+    :func:`exchanges.polymarket_market_data.get_market_resolution`). The
+    resolution dict is shaped ``{"closed": bool, "tokens": [{"winner": bool,
+    "price": float, ...}, ...]}`` with ``tokens`` ordered to match
+    ``outcomeIndex``.
+
+    Per-position handling (one bad market never aborts the sweep — each is
+    wrapped so a resolver/settle error is logged and counted, then skipped):
+
+      * resolver returns ``None`` OR ``closed`` is falsy -> leave OPEN
+        (``still_open``); an unresolved market must not be settled (no
+        look-ahead).
+      * ``outcomeIndex`` out of range for ``tokens`` (or unparseable from the
+        notes) -> skip + count ``errors``.
+      * ``entry_price <= 0`` -> skip + count ``unpriced``; we never fabricate a
+        realized PnL for an unmarkable entry.
+      * otherwise -> ``won = bool(token["winner"])`` (falling back to
+        ``token["price"] >= 0.5`` if ``winner`` is absent/false-y but the price
+        marks the outcome a winner), compute the realized PnL via
+        :func:`compute_settlement_pnl`, and append a ``settle`` event with
+        ``exit_price = 1.0`` (won) / ``0.0`` (lost), ``market_outcome =
+        "won:<side>"`` / ``"lost:<side>"`` and ``realized_pnl_usd``. The
+        ledger's own guard rejects an ``exit_ts`` before entry.
+
+    Args:
+        ledger: A :class:`state.pnl_ledger.PnlLedger` (or compatible) exposing
+            ``open_positions()`` and ``settle(...)``.
+        resolver: ``callable(market_id) -> resolution-dict | None``.
+        fee_bps: Settlement fee passed through to
+            :func:`compute_settlement_pnl`.
+        now_iso: Exit timestamp to record (ISO-8601 UTC). Defaults to now. Must
+            be at/after each record's entry time or the ledger guard rejects it.
+
+    Returns:
+        A counts dict::
+
+            {"settled", "won", "lost", "still_open", "unpriced", "errors",
+             "total_realized_pnl_usd"}
+    """
+    exit_ts = now_iso or _utc_now_iso()
+    counts = {
+        "settled": 0,
+        "won": 0,
+        "lost": 0,
+        "still_open": 0,
+        "unpriced": 0,
+        "errors": 0,
+        "total_realized_pnl_usd": 0.0,
+    }
+
+    try:
+        open_positions = ledger.open_positions()
+    except Exception as exc:  # pragma: no cover - never let a read crash the sweep.
+        logging.warning("shadow settlement: open_positions() failed (%s)", exc)
+        return counts
+
+    for record in open_positions:
+        try:
+            resolution = resolver(record.market_id)
+        except Exception as exc:  # noqa: BLE001 - one bad market must not abort the sweep.
+            logging.warning(
+                "shadow settlement: resolver(%s) raised (%s); leaving open.",
+                record.market_id,
+                exc,
+            )
+            counts["errors"] += 1
+            continue
+
+        if not resolution or not resolution.get("closed"):
+            counts["still_open"] += 1
+            continue
+
+        match = _OUTCOME_INDEX_RE.search(record.notes or "")
+        if match is None:
+            logging.warning(
+                "shadow settlement: no outcomeIndex in notes for trade %s; skipping.",
+                record.trade_id,
+            )
+            counts["errors"] += 1
+            continue
+        outcome_index = int(match.group(1))
+
+        tokens = resolution.get("tokens") or []
+        if not (0 <= outcome_index < len(tokens)):
+            logging.warning(
+                "shadow settlement: outcomeIndex %d out of range (%d tokens) "
+                "for trade %s; skipping.",
+                outcome_index,
+                len(tokens),
+                record.trade_id,
+            )
+            counts["errors"] += 1
+            continue
+        token = tokens[outcome_index]
+
+        # Prefer the explicit winner flag; fall back to the resolved price ONLY
+        # when it marks an unambiguous win (a closed market marks the winning
+        # token at exactly 1.0). The >=0.999 bound avoids mislabeling a
+        # degenerate closed-but-oddly-priced book as a win.
+        won = bool(token.get("winner"))
+        if not won:
+            price = token.get("price")
+            if isinstance(price, (int, float)) and price >= 0.999:
+                won = True
+
+        if record.entry_price is None or record.entry_price <= 0:
+            # Unmarkable entry (e.g. the /holders path that records 0.0): we
+            # cannot compute a realized PnL honestly, so never fabricate one.
+            counts["unpriced"] += 1
+            continue
+
+        pnl = compute_settlement_pnl(
+            float(record.entry_price), float(record.size), won, fee_bps=fee_bps
+        )
+
+        try:
+            ledger.settle(
+                record.trade_id,
+                exit_price=(1.0 if won else 0.0),
+                exit_ts_utc=exit_ts,
+                market_outcome=(f"won:{record.side}" if won else f"lost:{record.side}"),
+                realized_pnl_usd=pnl,
+            )
+        except Exception as exc:  # noqa: BLE001 - a single settle failure must not abort the sweep.
+            logging.warning(
+                "shadow settlement: settle(%s) failed (%s); leaving open.",
+                record.trade_id,
+                exc,
+            )
+            counts["errors"] += 1
+            continue
+
+        counts["settled"] += 1
+        counts["won" if won else "lost"] += 1
+        counts["total_realized_pnl_usd"] += pnl
+
+    counts["total_realized_pnl_usd"] = round(counts["total_realized_pnl_usd"], 4)
+    return counts

--- a/src/shadow_settlement.py
+++ b/src/shadow_settlement.py
@@ -34,6 +34,11 @@ import re
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, Optional
 
+try:  # Flat import under PYTHONPATH=src (matches the rest of the stack).
+    from state.pnl_ledger import dedupe_open_positions
+except Exception:  # pragma: no cover - alternate layout shim.
+    from src.state.pnl_ledger import dedupe_open_positions  # type: ignore
+
 
 __all__ = [
     "compute_settlement_pnl",
@@ -171,6 +176,13 @@ def settle_resolved_positions(
     except Exception as exc:  # pragma: no cover - never let a read crash the sweep.
         logging.warning("shadow settlement: open_positions() failed (%s)", exc)
         return counts
+
+    # Settle at most ONE record per (market, outcome). If two writers raced and
+    # wrote duplicate opens for the same position, settling both would book the
+    # realized P/L twice — so we settle the earliest and leave any duplicate
+    # untouched (it is hidden from the dashboard and retired by the runner's
+    # self-heal). Defense-in-depth: correct even if the heal has not run yet.
+    open_positions = dedupe_open_positions(open_positions)
 
     for record in open_positions:
         try:

--- a/src/shadow_settlement.py
+++ b/src/shadow_settlement.py
@@ -138,7 +138,7 @@ def settle_resolved_positions(
       * ``entry_price <= 0`` -> skip + count ``unpriced``; we never fabricate a
         realized PnL for an unmarkable entry.
       * otherwise -> ``won = bool(token["winner"])`` (falling back to
-        ``token["price"] >= 0.5`` if ``winner`` is absent/false-y but the price
+        ``token["price"] >= 0.999`` if ``winner`` is absent/false-y but the price
         marks the outcome a winner), compute the realized PnL via
         :func:`compute_settlement_pnl`, and append a ``settle`` event with
         ``exit_price = 1.0`` (won) / ``0.0`` (lost), ``market_outcome =

--- a/src/state/pnl_ledger.py
+++ b/src/state/pnl_ledger.py
@@ -45,6 +45,7 @@ DEFAULT_LEDGER_PATH = "runs/pnl_ledger.jsonl"
 # Event-kind discriminators written into each JSONL line under "_event".
 EVENT_OPEN = "open"
 EVENT_SETTLE = "settle"
+EVENT_CANCEL = "cancel"
 
 
 @dataclass
@@ -104,6 +105,56 @@ def _parse_iso8601(value: str) -> datetime:
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)
     return parsed.astimezone(timezone.utc)
+
+
+def _open_position_key(record: "TradeRecord") -> tuple:
+    """The identity of an open position for dedup: one per ``(market_id, side)``.
+
+    Two open records sharing this key are the SAME position — we shadow one unit
+    of a (market, outcome), never two. Such pairs only arise when two writers race
+    on the same ledger (each snapshots the open set before the other appends).
+    """
+    return (getattr(record, "market_id", None), getattr(record, "side", None))
+
+
+def dedupe_open_positions(records: List["TradeRecord"]) -> List["TradeRecord"]:
+    """Collapse open ``records`` to one per ``(market_id, side)``.
+
+    Keeps the EARLIEST-entered record for each key (by ``ts_utc``, which ISO-8601
+    sorts chronologically) — the original entry, whose decision-time price is the
+    honest one we'd have actually filled at. Input order is otherwise preserved
+    for the kept records. Pure and side-effect free; callers decide whether to
+    cancel the dropped duplicates in the ledger.
+    """
+    earliest: Dict[tuple, "TradeRecord"] = {}
+    for record in records:
+        key = _open_position_key(record)
+        kept = earliest.get(key)
+        if kept is None or (getattr(record, "ts_utc", "") or "") < (
+            getattr(kept, "ts_utc", "") or ""
+        ):
+            earliest[key] = record
+    # Preserve first-seen order of the kept records for stable display.
+    seen: set = set()
+    ordered: List["TradeRecord"] = []
+    for record in records:
+        key = _open_position_key(record)
+        if key in seen:
+            continue
+        seen.add(key)
+        ordered.append(earliest[key])
+    return ordered
+
+
+def duplicate_open_records(records: List["TradeRecord"]) -> List["TradeRecord"]:
+    """Return the DROPPED duplicate open records (everything dedup would discard).
+
+    These are the later-entered records that share a ``(market_id, side)`` with an
+    earlier one — the exact set a caller should :meth:`PnlLedger.cancel` to make
+    the ledger self-consistent (one open per market/outcome).
+    """
+    keep = {id(r) for r in dedupe_open_positions(records)}
+    return [r for r in records if id(r) not in keep]
 
 
 class PnlLedger:
@@ -187,6 +238,42 @@ class PnlLedger:
         )
         return record
 
+    def cancel(self, trade_id: str, reason: str = "") -> "TradeRecord":
+        """Append a ``cancel`` event for ``trade_id`` and return the folded record.
+
+        A cancel marks an OPEN record as ``cancelled`` so it drops out of both
+        :meth:`open_positions` and :meth:`settled` — it never contributes P/L and
+        never settles. This is the append-only way to retire a position that
+        should not have been opened (e.g. a duplicate written by two concurrent
+        writers racing on the same ledger): the original ``open`` line is left
+        intact for the audit trail, and a ``cancel`` line records the retraction
+        plus its ``reason``.
+
+        Unlike :meth:`settle` there is no exit price and no look-ahead concern (a
+        cancel carries no realized P/L), so there is no timestamp guard.
+
+        Raises
+        ------
+        KeyError
+            If ``trade_id`` has no prior ``open`` event in the ledger.
+        """
+        state = self._fold()
+        record = state.get(trade_id)
+        if record is None:
+            raise KeyError(f"cannot cancel unknown trade_id: {trade_id!r}")
+
+        cancel_payload: Dict[str, Any] = {
+            "_event": EVENT_CANCEL,
+            "trade_id": trade_id,
+            "status": "cancelled",
+        }
+        if reason:
+            cancel_payload["cancel_reason"] = reason
+        self._write_line(cancel_payload)
+
+        record.status = "cancelled"
+        return record
+
     def _write_line(self, payload: Dict[str, Any]) -> None:
         """Append a single JSON object as one line, flushing to disk.
 
@@ -231,6 +318,13 @@ class PnlLedger:
                     continue
                 if kind == EVENT_OPEN:
                     state[trade_id] = TradeRecord.from_dict(event)
+                elif kind == EVENT_CANCEL:
+                    record = state.get(trade_id)
+                    if record is None:
+                        # Cancel with no prior open — ignore (keep the audit
+                        # honest; we never fabricate an entry to cancel).
+                        continue
+                    record.status = event.get("status", "cancelled")
                 elif kind == EVENT_SETTLE:
                     record = state.get(trade_id)
                     if record is None:
@@ -256,6 +350,16 @@ class PnlLedger:
     def open_positions(self) -> List[TradeRecord]:
         """Return records still in ``open`` status."""
         return [r for r in self._fold().values() if r.status == "open"]
+
+    def unique_open_positions(self) -> List[TradeRecord]:
+        """Open positions collapsed to one per ``(market_id, side)``.
+
+        Defense-in-depth against duplicate opens written by concurrent writers:
+        readers that care about the *positions we actually hold* (the dashboard,
+        the settlement sweep) use this so a stray duplicate is never shown twice
+        nor settled twice. See :func:`dedupe_open_positions`.
+        """
+        return dedupe_open_positions(self.open_positions())
 
     def settled(self) -> List[TradeRecord]:
         """Return records in ``settled`` status."""
@@ -307,6 +411,9 @@ __all__ = [
     "DEFAULT_LEDGER_PATH",
     "EVENT_OPEN",
     "EVENT_SETTLE",
+    "EVENT_CANCEL",
     "PnlLedger",
     "TradeRecord",
+    "dedupe_open_positions",
+    "duplicate_open_records",
 ]

--- a/src/state/pnl_ledger.py
+++ b/src/state/pnl_ledger.py
@@ -8,14 +8,18 @@ this existed there was no auditable paper/backtest result anywhere in the repo.
 JSONL event-log model
 ---------------------
 The ledger is an **append-only JSONL file**: one JSON object per line, never
-rewritten in place. Each line is an immutable *event*. There are two event
-kinds, both keyed by ``trade_id``:
+rewritten in place. Each line is an immutable *event*. There are three event
+kinds, all keyed by ``trade_id``:
 
 1. ``"open"`` — emitted by :meth:`PnlLedger.append` when a position is entered.
    Carries the full :class:`TradeRecord` snapshot at decision/entry time.
 2. ``"settle"`` — emitted by :meth:`PnlLedger.settle` when the position closes.
    Carries the exit fields (``exit_price``, ``exit_ts_utc``, ``market_outcome``,
    ``realized_pnl_usd``, ``status``) plus the ``trade_id`` they apply to.
+3. ``"cancel"`` — emitted by :meth:`PnlLedger.cancel` to retire an ``open``
+   record (status -> ``cancelled``); carries no exit price and no realized P/L,
+   only the ``trade_id`` plus an optional ``cancel_reason``. Used by the
+   dedup-heal path to drop a duplicate open written by racing writers.
 
 Readers *fold* the event stream into current state: for each ``trade_id`` the
 latest event wins for the fields it carries. The file is therefore an immutable
@@ -35,7 +39,7 @@ from __future__ import annotations
 
 import json
 import os
-from dataclasses import asdict, dataclass, field, fields
+from dataclasses import asdict, dataclass, fields
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Union
 
@@ -354,10 +358,12 @@ class PnlLedger:
     def unique_open_positions(self) -> List[TradeRecord]:
         """Open positions collapsed to one per ``(market_id, side)``.
 
-        Defense-in-depth against duplicate opens written by concurrent writers:
-        readers that care about the *positions we actually hold* (the dashboard,
-        the settlement sweep) use this so a stray duplicate is never shown twice
-        nor settled twice. See :func:`dedupe_open_positions`.
+        Defense-in-depth against duplicate opens written by concurrent writers,
+        so the *positions we actually hold* are never counted twice. The
+        dashboard view-builder reads through this; the duck-typed sweeps
+        (:mod:`shadow_settlement`, :mod:`exit_rules`, :mod:`portfolio_reporter`)
+        call the module-level :func:`dedupe_open_positions` directly, since they
+        accept any ledger-like object, not only :class:`PnlLedger`.
         """
         return dedupe_open_positions(self.open_positions())
 

--- a/src/trade_blocklist.py
+++ b/src/trade_blocklist.py
@@ -1,0 +1,85 @@
+"""Do-not-trade blocklist: market topics we never want a position in.
+
+Operator policy filter (alcohol, casino/gambling, adult content by default, plus
+any operator-supplied terms). A market whose title/outcome matches a blocked
+term is excluded from shadow candidates and never logged — and the exclusion is
+reported (not silent), so it is always visible what was filtered out.
+
+Matching is case-insensitive and WHOLE-WORD (regex word boundaries) to avoid
+false positives like "winner" matching "wine" or "winnersexpo" matching a
+substring. Multi-word terms (e.g. "adult film") are matched as a phrase.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+__all__ = [
+    "DEFAULT_BLOCKED_TERMS",
+    "load_blocklist",
+    "blocked_term",
+]
+
+# Curated, conservative defaults. Kept deliberately specific to limit false
+# positives; operators tune via --blocklist-file. Lowercased here.
+DEFAULT_BLOCKED_TERMS = (
+    # --- Alcohol ---
+    "alcohol", "alcoholic", "beer", "wine", "liquor", "whiskey", "whisky",
+    "vodka", "tequila", "bourbon", "brewery", "brewing", "champagne",
+    # --- Casino / gambling ---
+    "casino", "gambling", "gamble", "blackjack", "roulette", "baccarat",
+    "slot machine", "sportsbook",
+    # --- Adult content ---
+    "porn", "pornography", "nsfw", "onlyfans", "xxx", "brothel",
+    "adult film", "adult content", "adult video",
+)
+
+
+def load_blocklist(
+    path: Optional[str] = None,
+    *,
+    extra_terms: Optional[Sequence[str]] = None,
+    include_defaults: bool = True,
+) -> List[str]:
+    """Build the blocklist: defaults + an optional file (one term per line,
+    ``#`` comments allowed) + ``extra_terms``. Terms are lowercased and
+    de-duplicated, order preserved.
+    """
+    terms: List[str] = list(DEFAULT_BLOCKED_TERMS) if include_defaults else []
+    if path:
+        fp = Path(path)
+        if fp.is_file():
+            for raw in fp.read_text().splitlines():
+                line = raw.strip()
+                if line and not line.startswith("#"):
+                    terms.append(line)
+    if extra_terms:
+        terms.extend(extra_terms)
+    out: List[str] = []
+    seen = set()
+    for term in terms:
+        norm = " ".join(str(term).strip().lower().split())
+        if norm and norm not in seen:
+            seen.add(norm)
+            out.append(norm)
+    return out
+
+
+def blocked_term(text: Optional[str], terms: Sequence[str]) -> Optional[str]:
+    """Return the FIRST blocked term that appears as a whole word/phrase in
+    ``text`` (case-insensitive), or ``None`` if nothing matches.
+
+    Whole-word matching avoids false positives: "wine" does not match "winner",
+    but does match "red wine market".
+    """
+    if not text or not terms:
+        return None
+    haystack = str(text)
+    for term in terms:
+        if not term:
+            continue
+        if re.search(r"\b" + re.escape(term) + r"\b", haystack, re.IGNORECASE):
+            return term
+    return None

--- a/src/whale_follow_runner.py
+++ b/src/whale_follow_runner.py
@@ -58,6 +58,18 @@ except Exception:  # pragma: no cover - import shim for alternate layouts.
         class PolymarketDataAPIError(Exception):  # type: ignore
             """Fallback when the data-api client cannot be imported."""
 
+try:  # Flat import under PYTHONPATH=src (matches the rest of the stack).
+    from trade_blocklist import blocked_term, load_blocklist
+except Exception:  # pragma: no cover - import shim for alternate layouts.
+    try:
+        from src.trade_blocklist import blocked_term, load_blocklist  # type: ignore
+    except Exception:  # pragma: no cover - degrade to no blocklist if missing.
+        def blocked_term(text, terms):  # type: ignore
+            return None
+
+        def load_blocklist(*_a, **_k):  # type: ignore
+            return []
+
 
 __all__ = [
     "STRATEGY",
@@ -280,10 +292,16 @@ def convergence_from_positions(
             seen_keys.add(key)
             bucket = per_market_outcome.setdefault(
                 key,
-                {"outcome": position.get("outcome"), "wallets": {}},
+                {
+                    "outcome": position.get("outcome"),
+                    "title": position.get("title"),
+                    "wallets": {},
+                },
             )
             if bucket["outcome"] is None:
                 bucket["outcome"] = position.get("outcome")
+            if not bucket.get("title"):
+                bucket["title"] = position.get("title")
             bucket["wallets"][wallet] = None  # ordered distinct set.
 
     candidates: List[Dict[str, Any]] = []
@@ -295,6 +313,7 @@ def convergence_from_positions(
                     "conditionId": condition_id,
                     "outcomeIndex": outcome_index,
                     "outcome": bucket["outcome"],
+                    "title": bucket.get("title"),
                     "n_target_holders": len(wallets),
                     "wallets": wallets,
                 }
@@ -435,8 +454,10 @@ def _log_candidates(
     mark_entry: bool = False,
     wallet_stats: Optional[Dict[str, Any]] = None,
     wallet_quality: Optional[Dict[str, float]] = None,
+    blocklist: Optional[Sequence[str]] = None,
+    dedup: bool = True,
 ) -> List[Dict[str, Any]]:
-    """Score + log a list of convergence candidates to the SHADOW ledger.
+    """Score + log convergence candidates to the SHADOW ledger.
 
     Shared back-end for both runner modes: the live ``/holders`` path
     (:func:`run_once` -> :func:`find_convergence`) and the leaderboard
@@ -445,12 +466,32 @@ def _log_candidates(
     entry pricing, ``TradeRecord`` construction, and notes are written in
     exactly one place — never duplicated.
 
-    For each candidate: compute confidence from the converging wallets' settled
-    win-rates (``wallet_stats``), optionally fetch a real decision-time entry
-    price (``mark_entry``), and append an OPEN :class:`TradeRecord`. NO orders
-    are placed — the client is read-only. Mutates each candidate in place with
-    ``confidence`` / ``confidence_label`` and returns the same list.
+    Two filters apply BEFORE logging:
+      * ``blocklist`` — operator do-not-trade terms (alcohol/casino/adult, etc.).
+        A candidate whose title/outcome matches is skipped (and counted, never
+        silently). Marked ``cand['blocked']=<term>``.
+      * ``dedup`` (default True) — never log a SECOND open position for a
+        ``(market, outcome)`` that already has one open in the ledger, so an
+        every-30-min loop doesn't pile up duplicates of the same convergence.
+        Marked ``cand['skipped']='duplicate_open'``.
+
+    For each surviving candidate: compute confidence, optionally fetch a real
+    decision-time entry price (``mark_entry``), and append an OPEN
+    :class:`TradeRecord`. NO orders are placed — the client is read-only.
+    Returns only the candidates actually LOGGED.
     """
+    existing_open = set()
+    if dedup:
+        try:
+            existing_open = {
+                (r.market_id, r.side) for r in ledger.open_positions()
+            }
+        except Exception:  # pragma: no cover - never let a read break logging.
+            existing_open = set()
+
+    logged: List[Dict[str, Any]] = []
+    n_blocked = 0
+    n_dup = 0
     for cand in candidates:
         outcome_label = cand.get("outcome")
         side = str(outcome_label) if outcome_label is not None else str(
@@ -459,6 +500,25 @@ def _log_candidates(
         wallets = cand.get("wallets") or []
         condition_id = str(cand.get("conditionId"))
         outcome_index = cand.get("outcomeIndex")
+
+        # Do-not-trade blocklist (operator policy): skip blocked topics. Matched
+        # against the market title + outcome label (title present in leaderboard
+        # mode via convergence_from_positions).
+        if blocklist:
+            match = blocked_term(
+                f"{cand.get('title') or ''} {outcome_label or ''}", blocklist
+            )
+            if match:
+                cand["blocked"] = match
+                n_blocked += 1
+                continue
+
+        # Dedup: one open position per (market, outcome) — no per-scan pile-up.
+        key = (condition_id, side)
+        if dedup and key in existing_open:
+            cand["skipped"] = "duplicate_open"
+            n_dup += 1
+            continue
 
         # Confidence = how many smart-money wallets converged x how good they
         # are. Quality is profit-leaderboard rank when available (leaderboard
@@ -523,9 +583,16 @@ def _log_candidates(
             notes=notes,
         )
         ledger.append(record)
+        existing_open.add(key)
+        logged.append(cand)
 
-    _print_summary(candidates)
-    return candidates
+    _print_summary(logged)
+    if n_blocked or n_dup:
+        print(
+            f"  (skipped {n_dup} already-open duplicate(s); "
+            f"blocked {n_blocked} do-not-trade market(s))"
+        )
+    return logged
 
 
 def run_once(
@@ -539,6 +606,8 @@ def run_once(
     mark_entry: bool = False,
     wallet_stats: Optional[Dict[str, Any]] = None,
     wallet_quality: Optional[Dict[str, float]] = None,
+    blocklist: Optional[Sequence[str]] = None,
+    dedup: bool = True,
     candidates: Optional[List[Dict[str, Any]]] = None,
 ) -> List[Dict[str, Any]]:
     """Run one convergence scan and log each candidate to the SHADOW ledger.
@@ -606,6 +675,8 @@ def run_once(
         mark_entry=mark_entry,
         wallet_stats=wallet_stats,
         wallet_quality=wallet_quality,
+        blocklist=blocklist,
+        dedup=dedup,
     )
 
 
@@ -711,9 +782,29 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                         help="In loop mode, re-rank smart-money wallets every N scans "
                         "(default 48); wallets are cached between re-ranks to avoid "
                         "hammering the per-wallet /positions calls.")
+    parser.add_argument("--blocklist-file", type=str, default=None,
+                        help="Path to an extra do-not-trade list (one term per line, "
+                        "# comments ok). Added on top of the built-in alcohol / "
+                        "casino / adult defaults.")
+    parser.add_argument("--no-blocklist", action="store_true",
+                        help="Disable the do-not-trade blocklist entirely.")
+    parser.add_argument("--no-dedup", action="store_true",
+                        help="Disable dedup (allow re-logging a convergence that "
+                        "already has an open position). Default keeps one per market.")
     args = parser.parse_args(argv)
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    # Do-not-trade blocklist (operator policy): built-in alcohol/casino/adult
+    # defaults plus any --blocklist-file terms. Empty when --no-blocklist.
+    blocklist = (
+        []
+        if args.no_blocklist
+        else load_blocklist(args.blocklist_file)
+    )
+    dedup = not args.no_dedup
+    if blocklist:
+        print(f"do-not-trade blocklist active: {len(blocklist)} term(s)")
 
     # Local imports keep the module importable without the data-api/ranker in
     # minimal/test environments (the unit tests inject fakes instead).
@@ -839,6 +930,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 mark_entry=True,
                 wallet_stats=wallet_stats,
                 wallet_quality=wallet_quality,
+                blocklist=blocklist,
+                dedup=dedup,
                 candidates=candidates,
             )
         else:
@@ -852,6 +945,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 size_usd=args.size,
                 mark_entry=True,
                 wallet_stats=wallet_stats,
+                blocklist=blocklist,
+                dedup=dedup,
             )
         _report()
 

--- a/src/whale_follow_runner.py
+++ b/src/whale_follow_runner.py
@@ -456,6 +456,7 @@ def _log_candidates(
     wallet_quality: Optional[Dict[str, float]] = None,
     blocklist: Optional[Sequence[str]] = None,
     dedup: bool = True,
+    min_confidence: float = 0.0,
 ) -> List[Dict[str, Any]]:
     """Score + log convergence candidates to the SHADOW ledger.
 
@@ -466,7 +467,7 @@ def _log_candidates(
     entry pricing, ``TradeRecord`` construction, and notes are written in
     exactly one place — never duplicated.
 
-    Two filters apply BEFORE logging:
+    Three filters apply BEFORE logging:
       * ``blocklist`` — operator do-not-trade terms (alcohol/casino/adult, etc.).
         A candidate whose title/outcome matches is skipped (and counted, never
         silently). Marked ``cand['blocked']=<term>``.
@@ -474,6 +475,11 @@ def _log_candidates(
         ``(market, outcome)`` that already has one open in the ledger, so an
         every-30-min loop doesn't pile up duplicates of the same convergence.
         Marked ``cand['skipped']='duplicate_open'``.
+      * ``min_confidence`` (function default 0.0 = off; the CLI overrides this to
+        0.5) — the ENTRY filter: after scoring, skip any candidate whose
+        ``confidence`` is below this floor, so only the STRONGEST convergences
+        (the most profitable to follow) are ever entered.
+        Counted (not silent); marked ``cand['skipped']='low_confidence'``.
 
     For each surviving candidate: compute confidence, optionally fetch a real
     decision-time entry price (``mark_entry``), and append an OPEN
@@ -492,6 +498,7 @@ def _log_candidates(
     logged: List[Dict[str, Any]] = []
     n_blocked = 0
     n_dup = 0
+    n_low_conf = 0
     for cand in candidates:
         outcome_label = cand.get("outcome")
         side = str(outcome_label) if outcome_label is not None else str(
@@ -549,6 +556,15 @@ def _log_candidates(
         cand["confidence"] = conf_score
         cand["confidence_label"] = conf_label
 
+        # ENTRY filter: only follow the strongest convergences. A candidate below
+        # the confidence floor is counted (never silently dropped) and skipped
+        # before any record is written — this is the "catch the most profitable"
+        # lever that keeps weak signals out of the shadow ledger entirely.
+        if conf_score < min_confidence:
+            cand["skipped"] = "low_confidence"
+            n_low_conf += 1
+            continue
+
         entry_price = 0.0
         if mark_entry and outcome_index is not None:
             entry_price = (
@@ -587,10 +603,11 @@ def _log_candidates(
         logged.append(cand)
 
     _print_summary(logged)
-    if n_blocked or n_dup:
+    if n_blocked or n_dup or n_low_conf:
         print(
             f"  (skipped {n_dup} already-open duplicate(s); "
-            f"blocked {n_blocked} do-not-trade market(s))"
+            f"blocked {n_blocked} do-not-trade market(s); "
+            f"skipped {n_low_conf} below-confidence candidate(s))"
         )
     return logged
 
@@ -608,6 +625,7 @@ def run_once(
     wallet_quality: Optional[Dict[str, float]] = None,
     blocklist: Optional[Sequence[str]] = None,
     dedup: bool = True,
+    min_confidence: float = 0.0,
     candidates: Optional[List[Dict[str, Any]]] = None,
 ) -> List[Dict[str, Any]]:
     """Run one convergence scan and log each candidate to the SHADOW ledger.
@@ -642,6 +660,9 @@ def run_once(
                                 0.0 — shadow positions carry no real size).
         mark_entry:             When True, fetch a real decision-time entry price
                                 per candidate via the data-api ``/trades`` page.
+        min_confidence:         ENTRY filter (default 0.0 = off): only log
+                                candidates whose computed ``confidence`` is
+                                >= this floor, keeping the strongest convergences.
         candidates:             OPTIONAL precomputed candidate list (same shape
                                 :func:`find_convergence` returns). When provided
                                 (e.g. leaderboard mode passes the output of
@@ -677,6 +698,7 @@ def run_once(
         wallet_quality=wallet_quality,
         blocklist=blocklist,
         dedup=dedup,
+        min_confidence=min_confidence,
     )
 
 
@@ -796,6 +818,26 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                         "(settlement ON) sweeps open positions at the start of each "
                         "scan, closing any whose Polymarket market has RESOLVED so "
                         "realized P/L shows in the report and dedup frees up.")
+    parser.add_argument("--min-confidence", type=float, default=0.5,
+                        help="ENTRY filter: only enter convergences whose computed "
+                        "confidence is >= this (default 0.5) — catch the most "
+                        "profitable, strongest convergences. 0.0 disables.")
+    parser.add_argument("--stop-loss-pct", type=float, default=0.40,
+                        help="Early-exit a position once it is down >= this fraction "
+                        "of its entry cost (default 0.40 = -40%%) — cap the loss "
+                        "instead of riding a loser to $0.")
+    parser.add_argument("--take-profit-pct", type=float, default=0.50,
+                        help="Early-exit a position once it is up >= this fraction "
+                        "of its entry cost (default 0.50 = +50%%) — lock the win.")
+    parser.add_argument("--take-profit-price", type=float, default=0.90,
+                        help="Early-exit a position once the outcome marks >= this "
+                        "absolute price (default 0.90) — a near-certain win, lock "
+                        "it in and redeploy.")
+    parser.add_argument("--no-exit-rules", action="store_true",
+                        help="Disable the stop-loss / take-profit early-exit sweep. "
+                        "Default (exit rules ON) sweeps open positions each scan "
+                        "and settles those past a stop/take-profit at the current "
+                        "mark (SHADOW-ONLY, NO orders).")
     args = parser.parse_args(argv)
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
@@ -816,6 +858,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     from exchanges.polymarket_data_api import PolymarketDataAPIClient
     from exchanges import polymarket_market_data
     import shadow_settlement
+    import exit_rules
     import wallet_ranker
 
     client = PolymarketDataAPIClient()
@@ -849,6 +892,33 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     # whale position to market (entry -> current). It re-prices via /trades using
     # the outcomeIndex marker in each record's notes; SHADOW/observability only.
     price_fn = make_whale_price_fn(client)
+
+    # Early-exit sweep (ON unless --no-exit-rules): re-price each open position to
+    # the CURRENT mark and settle those past the stop-loss / take-profit at that
+    # mark — capping losers (instead of riding to $0) and locking winners.
+    # SHADOW-ONLY read + ledger bookkeeping; places NO orders.
+    exit_rules_enabled = not args.no_exit_rules
+
+    def _apply_exit_rules() -> None:
+        """Sweep + early-exit open positions at the current mark. Never crashes
+        the loop (wrapped so a transient pricing error can't kill the scan)."""
+        if not exit_rules_enabled:
+            return
+        try:
+            res = exit_rules.apply_exit_rules(
+                ledger,
+                price_fn,
+                stop_loss_pct=args.stop_loss_pct,
+                take_profit_pct=args.take_profit_pct,
+                take_profit_price=args.take_profit_price,
+            )
+            print(
+                f"exits: {res['stop_loss']} stop-loss / "
+                f"{res['take_profit']} take-profit, "
+                f"realized ${res['realized_pnl_usd']:.2f}"
+            )
+        except Exception as exc:  # noqa: BLE001 - exit rules must never crash the scan.
+            logging.warning("exit-rules sweep failed (%s); continuing.", exc)
 
     # wallet -> WalletStats for the current roster, so each convergence candidate
     # can be scored on the win-rate of the wallets that actually converged.
@@ -941,10 +1011,15 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             )
 
     def _scan(targets: Sequence[str]) -> None:
-        # Settle resolved positions FIRST (before convergence detection): this
+        # (1) Settle resolved positions FIRST (before everything else): this
         # closes any market that has resolved since the last scan, freeing dedup
         # and surfacing realized P/L in the report.
         _settle()
+        # (2) Early-exit sweep: cap losers / lock winners at the CURRENT mark
+        # BEFORE opening new convergences, so the risk overlay runs on the
+        # already-open book each scan (SHADOW-ONLY, NO orders).
+        _apply_exit_rules()
+        # (3) Convergence detection -> log new candidates (entry-filtered).
         if args.roster_source == "leaderboard":
             # Convergence comes from the roster's CURRENT positions (not hot
             # markets). The same /positions fetch also yields per-wallet stats,
@@ -967,6 +1042,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 wallet_quality=wallet_quality,
                 blocklist=blocklist,
                 dedup=dedup,
+                min_confidence=args.min_confidence,
                 candidates=candidates,
             )
         else:
@@ -982,7 +1058,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 wallet_stats=wallet_stats,
                 blocklist=blocklist,
                 dedup=dedup,
+                min_confidence=args.min_confidence,
             )
+        # (4) Report.
         _report()
 
     # Single pass (default): rank once, scan once, report, done.

--- a/src/whale_follow_runner.py
+++ b/src/whale_follow_runner.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 import re
 import time
 import uuid
@@ -39,12 +40,18 @@ from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional, Sequence
 
 try:  # Flat import under PYTHONPATH=src (matches the rest of the stack).
-    from state.pnl_ledger import DEFAULT_LEDGER_PATH, PnlLedger, TradeRecord
+    from state.pnl_ledger import (
+        DEFAULT_LEDGER_PATH,
+        PnlLedger,
+        TradeRecord,
+        duplicate_open_records,
+    )
 except Exception:  # pragma: no cover - import shim for alternate layouts.
     from src.state.pnl_ledger import (  # type: ignore
         DEFAULT_LEDGER_PATH,
         PnlLedger,
         TradeRecord,
+        duplicate_open_records,
     )
 
 try:  # Flat import under PYTHONPATH=src (matches the rest of the stack).
@@ -87,6 +94,106 @@ _OUTCOME_INDEX_RE = re.compile(r"outcomeIndex=(\d+)")
 
 
 STRATEGY = "whale_convergence"
+
+
+def _heal_duplicate_opens(ledger: PnlLedger) -> int:
+    """Cancel duplicate OPEN records so the ledger holds one per (market, outcome).
+
+    Two writers racing on the same ledger can each append an ``open`` for the same
+    convergence (each snapshots the open set before the other's append lands),
+    leaving duplicate open records that would show twice on the dashboard and
+    settle twice (double-counted P/L). This retires the extras with an append-only
+    :meth:`PnlLedger.cancel` — the earliest entry per (market, outcome) is kept,
+    the later duplicates are cancelled. Idempotent: a clean ledger heals zero.
+
+    Returns the number of duplicate records cancelled. Never raises (a read/cancel
+    failure is logged and the scan continues — settlement and the view layer dedup
+    too, so an un-healed duplicate is still harmless).
+    """
+    try:
+        extras = duplicate_open_records(ledger.open_positions())
+    except Exception as exc:  # noqa: BLE001 - never let a read crash the loop.
+        logging.warning("dedup heal: open_positions() failed (%s); skipping.", exc)
+        return 0
+    cancelled = 0
+    for record in extras:
+        try:
+            ledger.cancel(
+                record.trade_id, reason="duplicate_open (concurrent-writer race)"
+            )
+            cancelled += 1
+        except Exception as exc:  # noqa: BLE001 - one bad cancel must not abort.
+            logging.warning(
+                "dedup heal: cancel(%s) failed (%s); leaving as-is.",
+                getattr(record, "trade_id", "?"),
+                exc,
+            )
+    if cancelled:
+        print(f"dedup heal: cancelled {cancelled} duplicate open record(s)")
+    return cancelled
+
+
+def _pid_alive(pid: int) -> bool:
+    """True if a process with ``pid`` is currently running (POSIX)."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:  # exists but owned by another user
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _acquire_ledger_lock(ledger_path: str) -> Optional[str]:
+    """Take a single-writer lock for ``ledger_path``; return the lock path or None.
+
+    Prevents the root cause of duplicate opens: two ``whale_follow_runner`` loops
+    writing the SAME ledger. The lock is a ``<ledger>.lock`` file holding this
+    process's PID. If a live PID already holds it, we refuse (return ``None`` and
+    print how to override). A stale lock (PID no longer running) is reclaimed.
+
+    Best-effort and POSIX-oriented; any filesystem error degrades to "no lock"
+    (returns the path) rather than blocking a legitimate run.
+    """
+    lock_path = f"{ledger_path}.lock"
+    try:
+        if os.path.exists(lock_path):
+            try:
+                with open(lock_path, "r", encoding="utf-8") as handle:
+                    holder = int((handle.read().strip() or "0"))
+            except (ValueError, OSError):
+                holder = 0
+            if holder and holder != os.getpid() and _pid_alive(holder):
+                print(
+                    f"REFUSING TO START: another writer (pid {holder}) already holds "
+                    f"{lock_path}. Two loops on one ledger create duplicate opens. "
+                    f"Stop it first (kill {holder}), or use a different --ledger-path."
+                )
+                return None
+        parent = os.path.dirname(os.path.abspath(lock_path))
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(lock_path, "w", encoding="utf-8") as handle:
+            handle.write(str(os.getpid()))
+        return lock_path
+    except OSError as exc:  # pragma: no cover - lock is best-effort, never fatal.
+        logging.warning("could not acquire ledger lock (%s); continuing.", exc)
+        return lock_path
+
+
+def _release_ledger_lock(lock_path: Optional[str]) -> None:
+    """Release a lock taken by :func:`_acquire_ledger_lock` (only if we own it)."""
+    if not lock_path:
+        return
+    try:
+        with open(lock_path, "r", encoding="utf-8") as handle:
+            holder = int((handle.read().strip() or "0"))
+        if holder == os.getpid():
+            os.remove(lock_path)
+    except (ValueError, OSError):
+        pass
 
 
 def find_convergence(
@@ -1011,6 +1118,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             )
 
     def _scan(targets: Sequence[str]) -> None:
+        # (0) Self-heal duplicate opens: retire any (market, outcome) that ended
+        # up with two open records (e.g. a past concurrent-writer race) so the
+        # rest of the scan — settle, exit rules, report — sees one per position
+        # and never double-counts. Idempotent; a clean ledger heals zero.
+        _heal_duplicate_opens(ledger)
         # (1) Settle resolved positions FIRST (before everything else): this
         # closes any market that has resolved since the last scan, freeing dedup
         # and surfacing realized P/L in the report.
@@ -1074,6 +1186,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     # don't hammer the N+1 /positions calls on every scan). Each iteration
     # re-derives hot markets, runs a scan, reports, and sleeps. Ctrl-C exits
     # cleanly with the no-orders affirmation.
+    #
+    # Single-writer lock: two loops on one ledger are the ROOT CAUSE of duplicate
+    # opens (each snapshots the open set before the other's append lands). Refuse
+    # to start a second live writer on the same ledger.
+    lock_path = _acquire_ledger_lock(args.ledger_path)
+    if lock_path is None:
+        return 1
     refresh = max(1, int(args.rank_refresh_scans))
     targets: List[str] = []
     iteration = 0
@@ -1099,6 +1218,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             time.sleep(args.interval)
     except KeyboardInterrupt:
         print("\nstopped by user. No orders were ever placed.")
+    finally:
+        _release_ledger_lock(lock_path)
     return 0
 
 

--- a/src/whale_follow_runner.py
+++ b/src/whale_follow_runner.py
@@ -158,25 +158,39 @@ def _acquire_ledger_lock(ledger_path: str) -> Optional[str]:
     (returns the path) rather than blocking a legitimate run.
     """
     lock_path = f"{ledger_path}.lock"
+    parent = os.path.dirname(os.path.abspath(lock_path))
     try:
-        if os.path.exists(lock_path):
-            try:
-                with open(lock_path, "r", encoding="utf-8") as handle:
-                    holder = int((handle.read().strip() or "0"))
-            except (ValueError, OSError):
-                holder = 0
-            if holder and holder != os.getpid() and _pid_alive(holder):
-                print(
-                    f"REFUSING TO START: another writer (pid {holder}) already holds "
-                    f"{lock_path}. Two loops on one ledger create duplicate opens. "
-                    f"Stop it first (kill {holder}), or use a different --ledger-path."
-                )
-                return None
-        parent = os.path.dirname(os.path.abspath(lock_path))
         if parent:
             os.makedirs(parent, exist_ok=True)
-        with open(lock_path, "w", encoding="utf-8") as handle:
-            handle.write(str(os.getpid()))
+        for _attempt in range(2):  # one retry after reclaiming a stale lock
+            try:
+                # ATOMIC create-or-fail: only one racer wins O_CREAT|O_EXCL, so
+                # two runners starting at once can't both pass a check and both
+                # write a PID.
+                fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    handle.write(str(os.getpid()))
+                return lock_path
+            except FileExistsError:
+                try:
+                    with open(lock_path, "r", encoding="utf-8") as handle:
+                        holder = int((handle.read().strip() or "0"))
+                except (ValueError, OSError):
+                    holder = 0
+                if holder == os.getpid():
+                    return lock_path  # already ours
+                if holder and _pid_alive(holder):
+                    print(
+                        f"REFUSING TO START: another writer (pid {holder}) already holds "
+                        f"{lock_path}. Two loops on one ledger create duplicate opens. "
+                        f"Stop it first (kill {holder}), or use a different --ledger-path."
+                    )
+                    return None
+                # Stale lock (holder gone / unreadable): reclaim and retry once.
+                try:
+                    os.remove(lock_path)
+                except OSError:
+                    return lock_path  # can't reclaim; degrade to no-lock
         return lock_path
     except OSError as exc:  # pragma: no cover - lock is best-effort, never fatal.
         logging.warning("could not acquire ledger lock (%s); continuing.", exc)

--- a/src/whale_follow_runner.py
+++ b/src/whale_follow_runner.py
@@ -62,6 +62,7 @@ except Exception:  # pragma: no cover - import shim for alternate layouts.
 __all__ = [
     "STRATEGY",
     "find_convergence",
+    "convergence_from_positions",
     "compute_confidence",
     "run_once",
     "make_whale_price_fn",
@@ -155,6 +156,154 @@ def find_convergence(
     return candidates
 
 
+def _is_current_open_holding(position: Dict[str, Any]) -> bool:
+    """Return True iff a position is a CURRENT open holding (not resolved).
+
+    A current open holding has real notional still at risk:
+      * ``size > 0`` — the wallet actually holds the outcome token now; and
+      * NOT ``redeemable`` — a redeemable position is resolved/settled; and
+      * ``0 < curPrice < 1`` — a resolved/settled outcome marks to exactly 0 or
+        1, so a strict-interior price is the live, still-uncertain signal.
+
+    Any missing/non-numeric field is treated as NOT a current holding, so an
+    ambiguous row never produces a false convergence signal.
+    """
+    try:
+        size = float(position.get("size"))
+    except (TypeError, ValueError):
+        return False
+    if size <= 0:
+        return False
+    if position.get("redeemable") is True:
+        return False
+    try:
+        cur_price = float(position.get("curPrice"))
+    except (TypeError, ValueError):
+        return False
+    return 0.0 < cur_price < 1.0
+
+
+def convergence_from_positions(
+    client: Any,
+    roster_wallets: Sequence[str],
+    *,
+    min_convergence: int = 3,
+    return_stats: bool = False,
+) -> Any:
+    """Flag markets where >= ``min_convergence`` roster wallets CURRENTLY hold the
+    same outcome, derived from each wallet's live ``/positions``.
+
+    This is the leaderboard-mode counterpart to :func:`find_convergence`. Instead
+    of scanning a fixed set of "hot" markets via ``/holders``, it asks each
+    roster wallet what it is *holding right now* and looks for the same
+    (market, outcome) showing up across several winners. That matters because an
+    all-time profit legend may be dormant in today's hot markets — the only way
+    to follow them is to read their current book.
+
+    For each wallet in ``roster_wallets`` we fetch
+    ``client.get_positions(user=wallet)`` and keep only CURRENT OPEN holdings
+    (:func:`_is_current_open_holding`: ``size>0``, not ``redeemable``,
+    ``0<curPrice<1``). Each surviving holding records the wallet under its
+    ``(conditionId, outcomeIndex)`` key. A per-wallet fetch error is caught and
+    that wallet is skipped (the scan continues) so one bad wallet can't sink it.
+
+    A (market, outcome) held by ``>= min_convergence`` DISTINCT roster wallets is
+    emitted as a candidate dict in the SAME shape :func:`find_convergence`
+    returns::
+
+        {conditionId, outcomeIndex, outcome, n_target_holders, wallets:[...]}
+
+    so the downstream confidence + mark-to-market + logging path is unchanged.
+
+    Args:
+        client:           Read-only data-api client exposing
+                          ``get_positions(user=..., limit=...)``.
+        roster_wallets:   The winners' roster (e.g. profit-leaderboard wallets).
+        min_convergence:  Min distinct roster wallets holding one outcome to flag.
+        return_stats:     When True, ALSO return ``wallet_stats`` —
+                          ``{wallet: WalletStats}`` built from the SAME positions
+                          already fetched (no extra calls), so confidence can be
+                          scored on each wallet's settled win-rate. A wallet that
+                          errored or returned nothing is absent from the map.
+
+    Returns:
+        ``candidates`` (a list of candidate dicts), or
+        ``(candidates, wallet_stats)`` when ``return_stats`` is True.
+    """
+    # Lazy import keeps this module importable without wallet_ranker in minimal
+    # envs; the stats path only runs when return_stats is requested.
+    stats_from_positions = None
+    if return_stats:
+        try:  # Flat import under PYTHONPATH=src (matches the rest of the stack).
+            from wallet_ranker import stats_from_positions  # type: ignore
+        except Exception:  # pragma: no cover - alternate layout shim.
+            from src.wallet_ranker import stats_from_positions  # type: ignore
+
+    roster = [w for w in roster_wallets if w]
+    # (conditionId, outcomeIndex) -> {"outcome": label, "wallets": ordered set}
+    per_market_outcome: Dict[tuple, Dict[str, Any]] = {}
+    wallet_stats: Dict[str, Any] = {}
+
+    for wallet in roster:
+        try:
+            positions = client.get_positions(user=wallet)
+        except PolymarketDataAPIError as exc:
+            logging.warning(
+                "skipping wallet %s: /positions failed (%s)", wallet, exc
+            )
+            continue
+        except Exception as exc:  # noqa: BLE001 - one bad wallet must not kill the scan.
+            logging.warning(
+                "skipping wallet %s: /positions raised (%s)", wallet, exc
+            )
+            continue
+
+        positions = positions or []
+        if return_stats and stats_from_positions is not None:
+            wallet_stats[wallet] = stats_from_positions(wallet, positions)
+
+        # A wallet is counted at most once per (market, outcome).
+        seen_keys: set = set()
+        for position in positions:
+            if not isinstance(position, dict):
+                continue
+            if not _is_current_open_holding(position):
+                continue
+            condition_id = position.get("conditionId")
+            outcome_index = position.get("outcomeIndex")
+            if not condition_id or outcome_index is None:
+                continue
+            key = (condition_id, outcome_index)
+            if key in seen_keys:
+                continue
+            seen_keys.add(key)
+            bucket = per_market_outcome.setdefault(
+                key,
+                {"outcome": position.get("outcome"), "wallets": {}},
+            )
+            if bucket["outcome"] is None:
+                bucket["outcome"] = position.get("outcome")
+            bucket["wallets"][wallet] = None  # ordered distinct set.
+
+    candidates: List[Dict[str, Any]] = []
+    for (condition_id, outcome_index), bucket in per_market_outcome.items():
+        wallets = list(bucket["wallets"].keys())
+        if len(wallets) >= min_convergence:
+            candidates.append(
+                {
+                    "conditionId": condition_id,
+                    "outcomeIndex": outcome_index,
+                    "outcome": bucket["outcome"],
+                    "n_target_holders": len(wallets),
+                    "wallets": wallets,
+                }
+            )
+
+    if return_stats:
+        return candidates, wallet_stats
+    return candidates
+
+
 def _utc_now_iso() -> str:
     """Current UTC time as an ISO-8601 string (decision/entry timestamp)."""
     return datetime.now(timezone.utc).isoformat()
@@ -243,63 +392,31 @@ def compute_confidence(
     return score, label
 
 
-def run_once(
+def _log_candidates(
     *,
     ledger: PnlLedger,
-    client: Optional[Any] = None,
-    target_wallets: Sequence[str],
-    markets_condition_ids: Sequence[str],
+    client: Any,
+    candidates: List[Dict[str, Any]],
     min_convergence: int = 3,
     size_usd: float = 0.0,
     mark_entry: bool = False,
     wallet_stats: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
-    """Run one convergence scan and log each candidate to the SHADOW ledger.
+    """Score + log a list of convergence candidates to the SHADOW ledger.
 
-    For every convergence candidate from :func:`find_convergence`, append an
-    OPEN :class:`TradeRecord` to ``ledger`` (``venue='polymarket'``,
-    ``strategy='whale_convergence'``, ``side`` = the converged outcome label).
-    The notes flag SHADOW MODE and list the contributing wallets so the
-    candidate is auditable. NO orders are placed — the client is read-only.
+    Shared back-end for both runner modes: the live ``/holders`` path
+    (:func:`run_once` -> :func:`find_convergence`) and the leaderboard
+    ``/positions`` path (:func:`convergence_from_positions`) hand the SAME
+    candidate shape to this one function, so the confidence, mark-to-market
+    entry pricing, ``TradeRecord`` construction, and notes are written in
+    exactly one place — never duplicated.
 
-    Entry price:
-        * ``mark_entry=False`` (default) — record ``entry_price = 0.0`` with the
-          legacy note, because the ``/holders`` endpoint carries no price. This
-          preserves the original behavior exactly (no ``get_trades`` call).
-        * ``mark_entry=True`` — set ``entry_price`` to the current market price of
-          the converged outcome via :func:`_latest_price_for_outcome` (the price
-          you'd pay to follow now, a decision-time entry — NOT look-ahead). When
-          a real price is found the note reflects it; when none is found we fall
-          back to ``0.0`` and keep the "holders endpoint carries no price" note.
-        Either way the ``outcomeIndex=<n>`` marker is preserved in the notes so
-        :func:`make_whale_price_fn` can re-price the open position later.
-
-    Args:
-        ledger:                 The shadow :class:`PnlLedger` to append to.
-        client:                 Read-only data-api client. Required in practice;
-                                kept optional for signature symmetry with other
-                                runners. A ``None`` client raises ``ValueError``.
-        target_wallets:         The smart-money roster.
-        markets_condition_ids:  Markets to scan.
-        min_convergence:        Convergence threshold (default 3).
-        size_usd:               Notional label for the shadow record (default
-                                0.0 — shadow positions carry no real size).
-        mark_entry:             When True, fetch a real decision-time entry price
-                                per candidate via the data-api ``/trades`` page.
-
-    Returns:
-        The list of convergence candidates that were logged.
+    For each candidate: compute confidence from the converging wallets' settled
+    win-rates (``wallet_stats``), optionally fetch a real decision-time entry
+    price (``mark_entry``), and append an OPEN :class:`TradeRecord`. NO orders
+    are placed — the client is read-only. Mutates each candidate in place with
+    ``confidence`` / ``confidence_label`` and returns the same list.
     """
-    if client is None:
-        raise ValueError("run_once requires a read-only data-api client")
-
-    candidates = find_convergence(
-        client,
-        target_wallets,
-        markets_condition_ids=markets_condition_ids,
-        min_convergence=min_convergence,
-    )
-
     for cand in candidates:
         outcome_label = cand.get("outcome")
         side = str(outcome_label) if outcome_label is not None else str(
@@ -370,6 +487,85 @@ def run_once(
     return candidates
 
 
+def run_once(
+    *,
+    ledger: PnlLedger,
+    client: Optional[Any] = None,
+    target_wallets: Sequence[str] = (),
+    markets_condition_ids: Sequence[str] = (),
+    min_convergence: int = 3,
+    size_usd: float = 0.0,
+    mark_entry: bool = False,
+    wallet_stats: Optional[Dict[str, Any]] = None,
+    candidates: Optional[List[Dict[str, Any]]] = None,
+) -> List[Dict[str, Any]]:
+    """Run one convergence scan and log each candidate to the SHADOW ledger.
+
+    For every convergence candidate from :func:`find_convergence`, append an
+    OPEN :class:`TradeRecord` to ``ledger`` (``venue='polymarket'``,
+    ``strategy='whale_convergence'``, ``side`` = the converged outcome label).
+    The notes flag SHADOW MODE and list the contributing wallets so the
+    candidate is auditable. NO orders are placed — the client is read-only.
+
+    Entry price:
+        * ``mark_entry=False`` (default) — record ``entry_price = 0.0`` with the
+          legacy note, because the ``/holders`` endpoint carries no price. This
+          preserves the original behavior exactly (no ``get_trades`` call).
+        * ``mark_entry=True`` — set ``entry_price`` to the current market price of
+          the converged outcome via :func:`_latest_price_for_outcome` (the price
+          you'd pay to follow now, a decision-time entry — NOT look-ahead). When
+          a real price is found the note reflects it; when none is found we fall
+          back to ``0.0`` and keep the "holders endpoint carries no price" note.
+        Either way the ``outcomeIndex=<n>`` marker is preserved in the notes so
+        :func:`make_whale_price_fn` can re-price the open position later.
+
+    Args:
+        ledger:                 The shadow :class:`PnlLedger` to append to.
+        client:                 Read-only data-api client. Required in practice;
+                                kept optional for signature symmetry with other
+                                runners. A ``None`` client raises ``ValueError``.
+        target_wallets:         The smart-money roster.
+        markets_condition_ids:  Markets to scan.
+        min_convergence:        Convergence threshold (default 3).
+        size_usd:               Notional label for the shadow record (default
+                                0.0 — shadow positions carry no real size).
+        mark_entry:             When True, fetch a real decision-time entry price
+                                per candidate via the data-api ``/trades`` page.
+        candidates:             OPTIONAL precomputed candidate list (same shape
+                                :func:`find_convergence` returns). When provided
+                                (e.g. leaderboard mode passes the output of
+                                :func:`convergence_from_positions`), the
+                                ``/holders`` scan is SKIPPED and these candidates
+                                are logged directly. When ``None`` (the live
+                                default), candidates are discovered from
+                                ``markets_condition_ids`` via
+                                :func:`find_convergence`.
+
+    Returns:
+        The list of convergence candidates that were logged.
+    """
+    if client is None:
+        raise ValueError("run_once requires a read-only data-api client")
+
+    if candidates is None:
+        candidates = find_convergence(
+            client,
+            target_wallets,
+            markets_condition_ids=markets_condition_ids,
+            min_convergence=min_convergence,
+        )
+
+    return _log_candidates(
+        ledger=ledger,
+        client=client,
+        candidates=candidates,
+        min_convergence=min_convergence,
+        size_usd=size_usd,
+        mark_entry=mark_entry,
+        wallet_stats=wallet_stats,
+    )
+
+
 def make_whale_price_fn(client: Any) -> Callable[[TradeRecord], Optional[float]]:
     """Build a ``price_fn(record) -> Optional[float]`` for the portfolio reporter.
 
@@ -409,16 +605,39 @@ def _print_summary(candidates: List[Dict[str, Any]]) -> None:
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
-    """CLI: rank smart-money wallets, scan hot markets for convergence, log to
-    the SHADOW ledger, and optionally post per-trade P/L + portfolio to Discord.
+    """CLI: build a winners' roster, detect convergence, log to the SHADOW
+    ledger, and optionally post per-trade P/L + portfolio to Discord.
 
-    Full pipeline, READ-ONLY + SHADOW: ranks wallets from the public data-api,
-    derives candidate markets from recent trades, flags convergence, and logs
-    candidates. NO orders are ever placed.
+    Two roster sources, READ-ONLY + SHADOW (NO orders are ever placed):
+
+    * ``--roster-source leaderboard`` (default) — the roster is Polymarket's
+      HISTORICAL PROFIT LEADERBOARD (``/profit``, real winners). Convergence
+      then comes from what those winners CURRENTLY hold (each wallet's
+      ``/positions``) via :func:`convergence_from_positions`, NOT from a fixed
+      set of "hot" markets — an all-time legend may be dormant in today's hot
+      markets, so the only way to follow them is to read their live book.
+    * ``--roster-source live`` — the EXACT prior behavior: discover active
+      wallets from recent trades, rank them by realized PnL/win-rate, derive
+      hot candidate markets, and flag convergence on ``/holders``.
+
+    Both paths feed the same confidence + mark-to-market + ledger logging.
     """
     parser = argparse.ArgumentParser(
         description="SHADOW whale-convergence follower (logs candidates, places NO orders)."
     )
+    parser.add_argument("--roster-source", choices=("live", "leaderboard"),
+                        default="leaderboard",
+                        help="Where the winners' roster comes from: 'leaderboard' "
+                        "(default) ranks Polymarket's historical /profit leaderboard "
+                        "and detects convergence from those wallets' CURRENT "
+                        "/positions; 'live' discovers + ranks active wallets and "
+                        "scans hot markets via /holders (the prior behavior).")
+    parser.add_argument("--leaderboard-window", type=str, default="all",
+                        help="Profit-leaderboard window for --roster-source leaderboard: "
+                        "'all' (all-time, default) or '1d' (today). Other values return HTTP 400.")
+    parser.add_argument("--leaderboard-limit", type=int, default=100,
+                        help="How many top profit-leaderboard wallets to pull as the "
+                        "roster (default 100).")
     parser.add_argument("--min-convergence", type=int, default=3,
                         help="Min distinct target wallets on one outcome to flag (default 3).")
     parser.add_argument("--top-wallets", type=int, default=30,
@@ -471,7 +690,33 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     wallet_stats: Dict[str, Any] = {}
 
     def _rank_targets() -> List[str]:
-        """Rank smart-money wallets (bounded discovery + per-wallet positions)."""
+        """Build the winners' roster for the configured ``--roster-source``.
+
+        * ``leaderboard`` — pull the top profit-leaderboard wallets (real
+          historical winners). ``wallet_stats`` is left empty here; it is filled
+          per-scan by :func:`convergence_from_positions` from the SAME
+          ``/positions`` fetch used to detect convergence (no extra calls).
+        * ``live`` — discover + rank active wallets and capture their
+          :class:`WalletStats` for confidence scoring (the prior behavior).
+        """
+        if args.roster_source == "leaderboard":
+            rows = client.get_profit_leaderboard(
+                window=args.leaderboard_window,
+                limit=args.leaderboard_limit,
+            )
+            targets: List[str] = []
+            for row in rows:
+                wallet = row.get("proxyWallet") if isinstance(row, dict) else None
+                if wallet and wallet not in targets:
+                    targets.append(wallet)
+            # Stats come from convergence_from_positions per scan, not from here.
+            wallet_stats.clear()
+            print(
+                f"loaded {len(targets)} profit-leaderboard wallet(s) "
+                f"(window={args.leaderboard_window!r})"
+            )
+            return targets
+
         discovered = wallet_ranker.discover_active_wallets(
             client, pages=args.discover_pages
         )
@@ -521,17 +766,39 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             )
 
     def _scan(targets: Sequence[str]) -> None:
-        market_ids = _hot_markets()
-        run_once(
-            ledger=ledger,
-            client=client,
-            target_wallets=targets,
-            markets_condition_ids=market_ids,
-            min_convergence=args.min_convergence,
-            size_usd=args.size,
-            mark_entry=True,
-            wallet_stats=wallet_stats,
-        )
+        if args.roster_source == "leaderboard":
+            # Convergence comes from the roster's CURRENT positions (not hot
+            # markets). The same /positions fetch also yields per-wallet stats,
+            # so confidence gets real win-rates with no extra calls.
+            candidates, stats = convergence_from_positions(
+                client,
+                targets,
+                min_convergence=args.min_convergence,
+                return_stats=True,
+            )
+            wallet_stats.clear()
+            wallet_stats.update(stats)
+            run_once(
+                ledger=ledger,
+                client=client,
+                min_convergence=args.min_convergence,
+                size_usd=args.size,
+                mark_entry=True,
+                wallet_stats=wallet_stats,
+                candidates=candidates,
+            )
+        else:
+            market_ids = _hot_markets()
+            run_once(
+                ledger=ledger,
+                client=client,
+                target_wallets=targets,
+                markets_condition_ids=market_ids,
+                min_convergence=args.min_convergence,
+                size_usd=args.size,
+                mark_entry=True,
+                wallet_stats=wallet_stats,
+            )
         _report()
 
     # Single pass (default): rank once, scan once, report, done.

--- a/src/whale_follow_runner.py
+++ b/src/whale_follow_runner.py
@@ -683,8 +683,14 @@ def _log_candidates(
             price_note = f"entry_price={entry_price:.4f} (latest /trades mark)"
         else:
             price_note = "entry_price=0.0 (holders endpoint carries no price)"
+        # Human market title (leaderboard mode carries it via /positions) so the
+        # dashboard shows a real name instead of a hex conditionId slug. Strip
+        # ';' so the `title=...;` marker stays parseable by clean_title.
+        title_raw = (cand.get("title") or "").replace(";", ",").strip()
+        title_note = f"title={title_raw}; " if title_raw else ""
         notes = (
             "SHADOW MODE - NO ORDERS; "
+            f"{title_note}"
             f"whale_convergence n={cand.get('n_target_holders')} "
             f"confidence={conf_score:.2f} ({conf_label}); "
             f"outcomeIndex={outcome_index}; "

--- a/src/whale_follow_runner.py
+++ b/src/whale_follow_runner.py
@@ -791,6 +791,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser.add_argument("--no-dedup", action="store_true",
                         help="Disable dedup (allow re-logging a convergence that "
                         "already has an open position). Default keeps one per market.")
+    parser.add_argument("--no-settle", action="store_true",
+                        help="Disable settlement of resolved positions. Default "
+                        "(settlement ON) sweeps open positions at the start of each "
+                        "scan, closing any whose Polymarket market has RESOLVED so "
+                        "realized P/L shows in the report and dedup frees up.")
     args = parser.parse_args(argv)
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
@@ -809,10 +814,36 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     # Local imports keep the module importable without the data-api/ranker in
     # minimal/test environments (the unit tests inject fakes instead).
     from exchanges.polymarket_data_api import PolymarketDataAPIClient
+    from exchanges import polymarket_market_data
+    import shadow_settlement
     import wallet_ranker
 
     client = PolymarketDataAPIClient()
     ledger = PnlLedger(args.ledger_path)
+
+    # Settlement (ON unless --no-settle): a resolver maps a market conditionId
+    # to its CLOB resolution status. SHADOW-ONLY read — closes resolved
+    # positions into the ledger, places NO orders.
+    settle_enabled = not args.no_settle
+    resolver = (
+        (lambda cid: polymarket_market_data.get_market_resolution(cid))
+        if settle_enabled
+        else None
+    )
+
+    def _settle() -> None:
+        """Sweep + settle any resolved open positions. Never crashes the loop."""
+        if not settle_enabled:
+            return
+        try:
+            res = shadow_settlement.settle_resolved_positions(ledger, resolver)
+            print(
+                f"settled {res['settled']}: {res['won']} won / "
+                f"{res['lost']} lost, realized ${res['total_realized_pnl_usd']:.2f}; "
+                f"still_open {res['still_open']}"
+            )
+        except Exception as exc:  # noqa: BLE001 - settlement must never crash the scan.
+            logging.warning("settlement sweep failed (%s); continuing.", exc)
 
     # A current-market price_fn so the Discord portfolio report marks each open
     # whale position to market (entry -> current). It re-prices via /trades using
@@ -910,6 +941,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             )
 
     def _scan(targets: Sequence[str]) -> None:
+        # Settle resolved positions FIRST (before convergence detection): this
+        # closes any market that has resolved since the last scan, freeing dedup
+        # and surfacing realized P/L in the report.
+        _settle()
         if args.roster_source == "leaderboard":
             # Convergence comes from the roster's CURRENT positions (not hot
             # markets). The same /positions fetch also yields per-wallet stats,

--- a/src/whale_follow_runner.py
+++ b/src/whale_follow_runner.py
@@ -64,6 +64,7 @@ __all__ = [
     "find_convergence",
     "convergence_from_positions",
     "compute_confidence",
+    "leaderboard_quality",
     "run_once",
     "make_whale_price_fn",
     "main",
@@ -362,31 +363,63 @@ def _latest_price_for_outcome(
     return best_price
 
 
+def leaderboard_quality(rank_index: int, total: int) -> float:
+    """Map a 0-based profit-leaderboard rank to a [0.6, 1.0] quality score.
+
+    Being on the all-time top-N profit board is itself strong evidence of skill,
+    so even the lowest-ranked board member earns an "elite floor" of 0.6, while
+    the #1 wallet earns 1.0. Used as the confidence QUALITY term in leaderboard
+    mode: these whales win on SIZE, not hit-rate, so their settled win-rate
+    (~0.5) badly understates them — profit-rank is the honest quality signal.
+    """
+    if total <= 1:
+        return 1.0
+    idx = max(0, min(int(rank_index), int(total) - 1))
+    return round(0.6 + 0.4 * (1.0 - idx / (int(total) - 1)), 3)
+
+
 def compute_confidence(
     n_target_holders: int,
     converging_winrates: Sequence[float],
     *,
     min_convergence: int = 3,
+    quality_scores: Optional[Sequence[float]] = None,
 ) -> tuple:
     """Heuristic 0-1 conviction for a whale-convergence candidate.
 
     This is a SIGNAL-STRENGTH indicator, NOT a probability of profit. It blends:
       * COUNT — how many smart-money wallets converged on the outcome
         (saturates at ~6 wallets); and
-      * QUALITY — the average historical win-rate of those converging wallets
-        (mapped 0.50 -> 0.0 .. 0.90 -> 1.0); neutral 0.5 when unknown.
+      * QUALITY — how good the converging wallets are. Two sources:
+          - ``quality_scores`` (preferred when given): pre-mapped per-wallet
+            quality in [0, 1] — e.g. profit-leaderboard rank via
+            :func:`leaderboard_quality`. Used as-is (averaged). This is what
+            leaderboard mode passes, because top-profit whales have ~0.5
+            win-rates that understate them.
+          - else ``converging_winrates``: historical settled win-rates mapped
+            0.50 -> 0.0 .. 0.90 -> 1.0; neutral 0.5 when unknown.
 
     Returns ``(score, label)`` where label is ``'low'`` (<0.40), ``'medium'``
     (<0.66), or ``'high'`` (>=0.66). More/better wallets agreeing = higher.
     """
     holders = max(int(n_target_holders or 0), int(min_convergence or 0))
     conv_term = max(0.0, min(1.0, holders / 6.0))
-    rates = [float(r) for r in converging_winrates if isinstance(r, (int, float))]
-    if rates:
-        avg_wr = sum(rates) / len(rates)
-        quality_term = max(0.0, min(1.0, (avg_wr - 0.5) / 0.4))
+    qualities = (
+        [float(q) for q in quality_scores if isinstance(q, (int, float))]
+        if quality_scores is not None
+        else []
+    )
+    if qualities:
+        quality_term = max(0.0, min(1.0, sum(qualities) / len(qualities)))
     else:
-        quality_term = 0.5  # neutral when wallet quality is unknown
+        rates = [
+            float(r) for r in converging_winrates if isinstance(r, (int, float))
+        ]
+        if rates:
+            avg_wr = sum(rates) / len(rates)
+            quality_term = max(0.0, min(1.0, (avg_wr - 0.5) / 0.4))
+        else:
+            quality_term = 0.5  # neutral when wallet quality is unknown
     score = round(0.5 * conv_term + 0.5 * quality_term, 3)
     label = "high" if score >= 0.66 else "medium" if score >= 0.40 else "low"
     return score, label
@@ -401,6 +434,7 @@ def _log_candidates(
     size_usd: float = 0.0,
     mark_entry: bool = False,
     wallet_stats: Optional[Dict[str, Any]] = None,
+    wallet_quality: Optional[Dict[str, float]] = None,
 ) -> List[Dict[str, Any]]:
     """Score + log a list of convergence candidates to the SHADOW ledger.
 
@@ -426,9 +460,15 @@ def _log_candidates(
         condition_id = str(cand.get("conditionId"))
         outcome_index = cand.get("outcomeIndex")
 
-        # Confidence = how many smart-money wallets converged x how good they are
-        # (avg historical win-rate from the ranking). Signal strength, not a
+        # Confidence = how many smart-money wallets converged x how good they
+        # are. Quality is profit-leaderboard rank when available (leaderboard
+        # mode), else historical win-rate (live mode). Signal strength, not a
         # profit probability. Stored on the candidate + in the notes for Discord.
+        quality_scores: List[float] = []
+        if wallet_quality:
+            quality_scores = [
+                float(wallet_quality[w]) for w in wallets if w in wallet_quality
+            ]
         winrates: List[float] = []
         if wallet_stats:
             for wallet in wallets:
@@ -444,6 +484,7 @@ def _log_candidates(
             int(cand.get("n_target_holders") or len(wallets)),
             winrates,
             min_convergence=min_convergence,
+            quality_scores=quality_scores or None,
         )
         cand["confidence"] = conf_score
         cand["confidence_label"] = conf_label
@@ -497,6 +538,7 @@ def run_once(
     size_usd: float = 0.0,
     mark_entry: bool = False,
     wallet_stats: Optional[Dict[str, Any]] = None,
+    wallet_quality: Optional[Dict[str, float]] = None,
     candidates: Optional[List[Dict[str, Any]]] = None,
 ) -> List[Dict[str, Any]]:
     """Run one convergence scan and log each candidate to the SHADOW ledger.
@@ -563,6 +605,7 @@ def run_once(
         size_usd=size_usd,
         mark_entry=mark_entry,
         wallet_stats=wallet_stats,
+        wallet_quality=wallet_quality,
     )
 
 
@@ -688,6 +731,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     # wallet -> WalletStats for the current roster, so each convergence candidate
     # can be scored on the win-rate of the wallets that actually converged.
     wallet_stats: Dict[str, Any] = {}
+    # wallet -> [0,1] quality from profit-leaderboard rank (leaderboard mode);
+    # empty in live mode, where confidence falls back to win-rate.
+    wallet_quality: Dict[str, float] = {}
 
     def _rank_targets() -> List[str]:
         """Build the winners' roster for the configured ``--roster-source``.
@@ -711,6 +757,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                     targets.append(wallet)
             # Stats come from convergence_from_positions per scan, not from here.
             wallet_stats.clear()
+            # Quality = profit-leaderboard rank (these whales win on size, not
+            # win-rate, so rank is the honest quality signal for confidence).
+            wallet_quality.clear()
+            wallet_quality.update(
+                {w: leaderboard_quality(i, len(targets)) for i, w in enumerate(targets)}
+            )
             print(
                 f"loaded {len(targets)} profit-leaderboard wallet(s) "
                 f"(window={args.leaderboard_window!r})"
@@ -730,6 +782,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         targets = [w.wallet for w in ranked]
         wallet_stats.clear()
         wallet_stats.update({w.wallet: w for w in ranked})
+        wallet_quality.clear()  # live mode scores on win-rate, not rank
         print(
             f"ranked {len(targets)} smart-money wallet(s) from "
             f"{len(discovered)} active"
@@ -785,6 +838,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 size_usd=args.size,
                 mark_entry=True,
                 wallet_stats=wallet_stats,
+                wallet_quality=wallet_quality,
                 candidates=candidates,
             )
         else:

--- a/tests/prediction_market_scanner/test_blocklist_dedup.py
+++ b/tests/prediction_market_scanner/test_blocklist_dedup.py
@@ -1,0 +1,158 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from state.pnl_ledger import PnlLedger, TradeRecord
+import whale_follow_runner as wf
+from whale_follow_runner import _log_candidates
+import trade_blocklist as tb
+
+
+class BlocklistMatchTest(unittest.TestCase):
+    def setUp(self):
+        self.terms = tb.load_blocklist()
+
+    def test_blocks_alcohol_casino_adult(self):
+        self.assertEqual(tb.blocked_term("Will this beer brand IPO?", self.terms), "beer")
+        self.assertEqual(tb.blocked_term("New casino in Vegas", self.terms), "casino")
+        self.assertIsNotNone(tb.blocked_term("OnlyFans top creator 2026", self.terms))
+
+    def test_no_false_positive_word_boundary(self):
+        # 'wine' must NOT match 'winner'; common market words stay tradeable.
+        self.assertIsNone(tb.blocked_term("Who will be the winner?", self.terms))
+        self.assertIsNone(tb.blocked_term("S&P 500 close above 6000", self.terms))
+        self.assertIsNone(tb.blocked_term("US presidential election result", self.terms))
+
+    def test_case_insensitive_and_multiword(self):
+        self.assertEqual(tb.blocked_term("ADULT FILM awards night", self.terms), "adult film")
+
+    def test_file_and_extra_terms(self):
+        d = tempfile.mkdtemp()
+        fp = Path(d) / "bl.txt"
+        fp.write_text("# my extras\ncrypto rug\n")
+        terms = tb.load_blocklist(str(fp), extra_terms=["tobacco"])
+        self.assertIn("tobacco", terms)
+        self.assertIn("crypto rug", terms)
+        self.assertEqual(tb.blocked_term("Tobacco ban referendum", terms), "tobacco")
+
+    def test_no_blocklist_blocks_nothing(self):
+        self.assertIsNone(tb.blocked_term("Casino stock", []))
+
+
+class _NoMarkClient:
+    """mark_entry=False path needs no client calls."""
+
+
+def _cand(cid, outcome, wallets, *, title=None, oi=0):
+    return {
+        "conditionId": cid,
+        "outcomeIndex": oi,
+        "outcome": outcome,
+        "title": title,
+        "n_target_holders": len(wallets),
+        "wallets": wallets,
+    }
+
+
+def _open_record(market_id, side):
+    return TradeRecord(
+        trade_id=f"x-{market_id}-{side}",
+        ts_utc="2026-06-01T00:00:00+00:00",
+        venue="polymarket",
+        market_id=market_id,
+        side=side,
+        entry_price=0.5,
+        size=100.0,
+        fees_usd=0.0,
+        slippage_bps=0.0,
+        strategy="whale_convergence",
+        status="open",
+    )
+
+
+class DedupTest(unittest.TestCase):
+    def test_skips_already_open_market_outcome(self):
+        led = PnlLedger(str(Path(tempfile.mkdtemp()) / "l.jsonl"))
+        led.append(_open_record("c1", "Yes"))
+        logged = _log_candidates(
+            ledger=led, client=_NoMarkClient(),
+            candidates=[_cand("c1", "Yes", ["a", "b", "c"])],
+            min_convergence=3, mark_entry=False, dedup=True,
+        )
+        self.assertEqual(len(logged), 0)  # already open -> not re-logged
+
+    def test_different_market_still_logs(self):
+        led = PnlLedger(str(Path(tempfile.mkdtemp()) / "l.jsonl"))
+        led.append(_open_record("c1", "Yes"))
+        logged = _log_candidates(
+            ledger=led, client=_NoMarkClient(),
+            candidates=[_cand("c2", "No", ["a", "b", "c"])],
+            min_convergence=3, mark_entry=False, dedup=True,
+        )
+        self.assertEqual(len(logged), 1)
+
+    def test_dedup_within_one_batch(self):
+        led = PnlLedger(str(Path(tempfile.mkdtemp()) / "l.jsonl"))
+        cands = [_cand("c1", "Yes", ["a", "b", "c"]), _cand("c1", "Yes", ["a", "b", "c"])]
+        logged = _log_candidates(
+            ledger=led, client=_NoMarkClient(), candidates=cands,
+            min_convergence=3, mark_entry=False, dedup=True,
+        )
+        self.assertEqual(len(logged), 1)
+
+    def test_no_dedup_allows_relog(self):
+        led = PnlLedger(str(Path(tempfile.mkdtemp()) / "l.jsonl"))
+        led.append(_open_record("c1", "Yes"))
+        logged = _log_candidates(
+            ledger=led, client=_NoMarkClient(),
+            candidates=[_cand("c1", "Yes", ["a", "b", "c"])],
+            min_convergence=3, mark_entry=False, dedup=False,
+        )
+        self.assertEqual(len(logged), 1)
+
+
+class BlocklistLogTest(unittest.TestCase):
+    def test_blocked_market_not_logged(self):
+        led = PnlLedger(str(Path(tempfile.mkdtemp()) / "l.jsonl"))
+        terms = tb.load_blocklist()
+        cands = [
+            _cand("c1", "Yes", ["a", "b", "c"], title="Best casino stock 2026"),
+            _cand("c2", "No", ["a", "b", "c"], title="US election outcome"),
+        ]
+        logged = _log_candidates(
+            ledger=led, client=_NoMarkClient(), candidates=cands,
+            min_convergence=3, mark_entry=False, blocklist=terms, dedup=True,
+        )
+        self.assertEqual(len(logged), 1)
+        self.assertEqual(logged[0]["conditionId"], "c2")
+        self.assertEqual(cands[0].get("blocked"), "casino")
+
+
+class _PosClient:
+    def __init__(self, by_wallet):
+        self._by = by_wallet
+
+    def get_positions(self, user, limit=500):
+        return self._by.get(user, [])
+
+
+def _pos(cid, title, *, oi=0, outcome="Yes", size=10.0, cur=0.5, redeemable=False):
+    return {
+        "conditionId": cid, "outcomeIndex": oi, "title": title, "outcome": outcome,
+        "size": size, "curPrice": cur, "redeemable": redeemable,
+    }
+
+
+class ConvergenceTitleTest(unittest.TestCase):
+    def test_title_captured_into_candidate(self):
+        client = _PosClient({
+            "w1": [_pos("c1", "Casino IPO date")],
+            "w2": [_pos("c1", "Casino IPO date")],
+        })
+        cands = wf.convergence_from_positions(client, ["w1", "w2"], min_convergence=2)
+        self.assertEqual(len(cands), 1)
+        self.assertEqual(cands[0]["title"], "Casino IPO date")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/prediction_market_scanner/test_confidence.py
+++ b/tests/prediction_market_scanner/test_confidence.py
@@ -129,5 +129,57 @@ class ReporterConfidenceDisplayTest(unittest.TestCase):
         self.assertNotIn("conf ", joined)
 
 
+class LeaderboardQualityTest(unittest.TestCase):
+    def test_top_rank_is_one(self):
+        self.assertEqual(wf.leaderboard_quality(0, 50), 1.0)
+
+    def test_bottom_rank_is_floor(self):
+        self.assertAlmostEqual(wf.leaderboard_quality(49, 50), 0.6, places=3)
+
+    def test_single_wallet_is_one(self):
+        self.assertEqual(wf.leaderboard_quality(0, 1), 1.0)
+
+    def test_monotonic_decreasing(self):
+        self.assertGreater(
+            wf.leaderboard_quality(0, 50), wf.leaderboard_quality(25, 50)
+        )
+
+
+class ConfidenceQualityScoresTest(unittest.TestCase):
+    def test_quality_scores_override_winrates(self):
+        # Win-rate 0.5 alone -> quality 0 -> low; but elite quality_scores win.
+        lo, lo_label = wf.compute_confidence(3, [0.5, 0.5], min_convergence=3)
+        hi, hi_label = wf.compute_confidence(
+            3, [0.5, 0.5], min_convergence=3, quality_scores=[0.99, 0.98, 0.97]
+        )
+        self.assertGreater(hi, lo)
+        self.assertEqual(hi_label, "high")  # 0.5*0.5 + 0.5*~0.98 = ~0.74
+
+    def test_three_elite_wallets_read_high(self):
+        # The exact leaderboard recalibration goal: 3 top wallets co-holding
+        # should NOT read 'low' anymore.
+        q = [wf.leaderboard_quality(i, 50) for i in (0, 1, 2)]
+        score, label = wf.compute_confidence(3, [], min_convergence=3, quality_scores=q)
+        self.assertEqual(label, "high")
+
+
+class RunOnceLeaderboardQualityTest(unittest.TestCase):
+    def test_wallet_quality_used_for_confidence(self):
+        led = PnlLedger(str(Path(tempfile.mkdtemp()) / "l.jsonl"))
+        cands = wf.run_once(
+            ledger=led,
+            client=_HoldersClient(),
+            target_wallets=["wA", "wB"],
+            markets_condition_ids=["c1"],
+            min_convergence=2,
+            mark_entry=False,
+            wallet_quality={"wA": 0.99, "wB": 0.98},  # elite -> should lift score
+        )
+        self.assertEqual(len(cands), 1)
+        # 2 holders (conv 2/6=0.333) + elite quality ~0.985 -> ~0.66 -> high/medium
+        self.assertIn(cands[0]["confidence_label"], ("medium", "high"))
+        self.assertGreater(cands[0]["confidence"], 0.4)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/prediction_market_scanner/test_confidence.py
+++ b/tests/prediction_market_scanner/test_confidence.py
@@ -181,5 +181,54 @@ class RunOnceLeaderboardQualityTest(unittest.TestCase):
         self.assertGreater(cands[0]["confidence"], 0.4)
 
 
+class MinConfidenceEntryFilterTest(unittest.TestCase):
+    """The ENTRY filter: skip convergences below the confidence floor.
+
+    Drives run_once on the same _HoldersClient (wA + wB converge on idx 0 of c1).
+    A low quality forces a low confidence (~0.25); a high quality forces a high
+    one (>=0.5). We assert the low one is NOT logged when min_confidence=0.5 and
+    the high one IS — proving the filter catches only the strongest signals.
+    """
+
+    def _run(self, *, min_confidence, wallet_quality):
+        led = PnlLedger(str(Path(tempfile.mkdtemp()) / "l.jsonl"))
+        cands = wf.run_once(
+            ledger=led,
+            client=_HoldersClient(),
+            target_wallets=["wA", "wB"],
+            markets_condition_ids=["c1"],
+            min_convergence=2,
+            mark_entry=False,
+            wallet_quality=wallet_quality,
+            min_confidence=min_confidence,
+        )
+        return led, cands
+
+    def test_low_confidence_candidate_not_logged(self):
+        # 2 holders (conv 2/6=0.333) + weak quality 0.10 -> conf ~0.22 < 0.5.
+        led, cands = self._run(
+            min_confidence=0.5, wallet_quality={"wA": 0.10, "wB": 0.10}
+        )
+        self.assertEqual(cands, [])  # filtered out before logging
+        self.assertEqual(led.all_records(), [])  # nothing written to the ledger
+
+    def test_high_confidence_candidate_logged(self):
+        # 2 holders (conv 2/6=0.333) + elite quality ~0.985 -> conf ~0.66 >= 0.5.
+        led, cands = self._run(
+            min_confidence=0.5, wallet_quality={"wA": 0.99, "wB": 0.98}
+        )
+        self.assertEqual(len(cands), 1)
+        self.assertGreaterEqual(cands[0]["confidence"], 0.5)
+        self.assertEqual(len(led.all_records()), 1)
+
+    def test_default_min_confidence_zero_logs_everything(self):
+        # min_confidence defaults to 0.0 (off): even a weak signal is logged.
+        led, cands = self._run(
+            min_confidence=0.0, wallet_quality={"wA": 0.10, "wB": 0.10}
+        )
+        self.assertEqual(len(cands), 1)
+        self.assertEqual(len(led.all_records()), 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/prediction_market_scanner/test_dashboard_state.py
+++ b/tests/prediction_market_scanner/test_dashboard_state.py
@@ -1,0 +1,250 @@
+"""Tests for src/dashboard/state.py (READ-ONLY observability).
+
+``build_state`` is driven against a real tempfile :class:`PnlLedger` carrying a
+mix of open + settled records (a stop-loss exit, a take-profit exit, a resolution
+win, and a resolution loss). No sockets, no network: we test the pure state
+builder directly. We assert:
+
+  * summary counts (n_open / n_settled) match the seeded book;
+  * exit_mix categorizes 'exit:stop_loss'/'exit:take_profit' by reason and
+    resolution settlements by realized-P/L sign (won/lost);
+  * the equity_curve starts at bankroll, is monotonic-in-time (sorted ASC), and
+    its final equity == bankroll + total realized P/L;
+  * confidence is parsed out of the notes marker for open positions;
+  * closed_positions is the exit feed sorted DESC by exit_ts_utc (newest first).
+
+READ-ONLY: the state builder reads the ledger and shapes it for display — there
+is no order/settle/write surface anywhere in the module under test.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+from dashboard.state import (
+    build_state,
+    clean_title,
+    normalize_exit_reason,
+    parse_confidence,
+)
+from state.pnl_ledger import PnlLedger, TradeRecord
+
+# Entry/exit timestamps chosen so exit_ts >= entry ts (ledger look-ahead guard)
+# and so the four settlements have a clear, distinct chronological order.
+ENTRY_TS = "2026-06-01T12:00:00+00:00"
+EXIT_T1 = "2026-06-02T09:00:00+00:00"  # stop-loss (oldest exit)
+EXIT_T2 = "2026-06-02T11:00:00+00:00"  # take-profit
+EXIT_T3 = "2026-06-02T13:00:00+00:00"  # resolution win
+EXIT_T4 = "2026-06-02T15:00:00+00:00"  # resolution loss (newest exit)
+
+BANKROLL = 1000.0
+
+
+def _open_record(trade_id, *, side, market_id, notes, entry_price=0.5):
+    return TradeRecord(
+        trade_id=trade_id,
+        ts_utc=ENTRY_TS,
+        venue="polymarket",
+        market_id=market_id,
+        side=side,
+        entry_price=entry_price,
+        size=100.0,
+        fees_usd=0.0,
+        slippage_bps=0.0,
+        strategy="whale_convergence",
+        notes=notes,
+    )
+
+
+class BuildStateTest(unittest.TestCase):
+    def setUp(self):
+        fd, self.path = tempfile.mkstemp(suffix=".jsonl")
+        os.close(fd)
+        self.ledger = PnlLedger(self.path)
+
+        # One open position (stays open), with a confidence marker in notes.
+        self.ledger.append(
+            _open_record(
+                "whale-open-1",
+                side="Milwaukee Brewers",
+                market_id="0x" + "a" * 60,
+                notes="SHADOW MODE - NO ORDERS; whale_convergence n=3 "
+                "confidence=0.65 (medium); outcomeIndex=0",
+            )
+        )
+        # A second open position with a HIGH confidence label.
+        self.ledger.append(
+            _open_record(
+                "whale-open-2",
+                side="Kansas City Royals",
+                market_id="0x" + "b" * 60,
+                notes="SHADOW MODE; whale_convergence n=4 confidence=0.73 (high)",
+            )
+        )
+
+        # Four positions that will be settled four different ways.
+        for tid, side in [
+            ("whale-stop", "Anastasia Potapova"),
+            ("whale-tp", "Felix Auger-Aliassime"),
+            ("whale-won", "Anna Kalinskaya"),
+            ("whale-lost", "Diane Parry"),
+        ]:
+            self.ledger.append(
+                _open_record(
+                    tid,
+                    side=side,
+                    market_id="0x" + tid.encode().hex(),
+                    notes="SHADOW MODE; whale_convergence confidence=0.60 (medium)",
+                )
+            )
+
+        # stop-loss exit: market_outcome 'exit:stop_loss', realized loss.
+        self.ledger.settle(
+            "whale-stop", exit_price=0.40, exit_ts_utc=EXIT_T1,
+            market_outcome="exit:stop_loss", realized_pnl_usd=-18.0,
+        )
+        # take-profit exit: market_outcome 'exit:take_profit', realized gain.
+        self.ledger.settle(
+            "whale-tp", exit_price=0.70, exit_ts_utc=EXIT_T2,
+            market_outcome="exit:take_profit", realized_pnl_usd=39.0,
+        )
+        # resolution win: non-exit outcome, positive realized.
+        self.ledger.settle(
+            "whale-won", exit_price=1.0, exit_ts_utc=EXIT_T3,
+            market_outcome="won:Anna Kalinskaya", realized_pnl_usd=100.0,
+        )
+        # resolution loss: non-exit outcome, non-positive realized.
+        self.ledger.settle(
+            "whale-lost", exit_price=0.0, exit_ts_utc=EXIT_T4,
+            market_outcome="lost:Diane Parry", realized_pnl_usd=-100.0,
+        )
+
+        self.state = build_state(self.ledger, bankroll_usd=BANKROLL)
+
+    def tearDown(self):
+        try:
+            os.remove(self.path)
+        except OSError:
+            pass
+
+    # ---- summary counts ----
+    def test_summary_counts(self):
+        s = self.state["summary"]
+        self.assertEqual(s["n_open"], 2)
+        self.assertEqual(s["n_settled"], 4)
+        self.assertEqual(s["bankroll_usd"], BANKROLL)
+        # realized = -18 + 39 + 100 - 100 = 21
+        self.assertAlmostEqual(s["realized_pnl_usd"], 21.0, places=6)
+        # 2 winners (tp, won) out of 4 settled.
+        self.assertAlmostEqual(s["win_rate"], 0.5, places=6)
+
+    # ---- exit_mix categorization ----
+    def test_exit_mix_categorization(self):
+        mix = self.state["exit_mix"]
+        self.assertEqual(mix.get("stop_loss"), 1)
+        self.assertEqual(mix.get("take_profit"), 1)
+        self.assertEqual(mix.get("won"), 1)
+        self.assertEqual(mix.get("lost"), 1)
+        # exactly four buckets accounted for, summing to n_settled.
+        self.assertEqual(sum(mix.values()), 4)
+
+    def test_normalize_exit_reason_helper(self):
+        self.assertEqual(normalize_exit_reason("exit:stop_loss", -5.0), "stop_loss")
+        self.assertEqual(normalize_exit_reason("exit:take_profit", 5.0), "take_profit")
+        self.assertEqual(normalize_exit_reason("won:Someone", 5.0), "won")
+        self.assertEqual(normalize_exit_reason("lost:Someone", -5.0), "lost")
+        # A resolution with zero realized is a loss (not strictly positive).
+        self.assertEqual(normalize_exit_reason("resolved", 0.0), "lost")
+        # None outcome falls through to realized-sign logic.
+        self.assertEqual(normalize_exit_reason(None, 1.0), "won")
+
+    # ---- equity curve ----
+    def test_equity_curve_starts_at_bankroll_and_is_time_ordered(self):
+        curve = self.state["equity_curve"]
+        # start point + one per settlement.
+        self.assertEqual(len(curve), 5)
+        self.assertEqual(curve[0]["t"], "start")
+        self.assertAlmostEqual(curve[0]["equity"], BANKROLL, places=6)
+
+        # Timestamps (after the start sentinel) are strictly ascending.
+        ts = [p["t"] for p in curve[1:]]
+        self.assertEqual(ts, sorted(ts))
+        self.assertEqual(ts, [EXIT_T1, EXIT_T2, EXIT_T3, EXIT_T4])
+
+    def test_equity_curve_ends_at_bankroll_plus_total_realized(self):
+        curve = self.state["equity_curve"]
+        total_realized = self.state["summary"]["realized_pnl_usd"]
+        self.assertAlmostEqual(
+            curve[-1]["equity"], BANKROLL + total_realized, places=6
+        )
+        # Spot-check the running accumulation along the way.
+        self.assertAlmostEqual(curve[1]["equity"], BANKROLL - 18.0, places=6)
+        self.assertAlmostEqual(curve[2]["equity"], BANKROLL - 18.0 + 39.0, places=6)
+
+    # ---- confidence parsing on open positions ----
+    def test_open_positions_parse_confidence(self):
+        opens = {p["title"]: p for p in self.state["open_positions"]}
+        self.assertEqual(len(self.state["open_positions"]), 2)
+        confs = sorted(
+            (p["confidence"]["score"], p["confidence"]["label"])
+            for p in self.state["open_positions"]
+        )
+        self.assertEqual(confs, [(0.65, "medium"), (0.73, "high")])
+        # Each open carries its side and a numeric entry price.
+        for p in self.state["open_positions"]:
+            self.assertIn(p["side"], ("Milwaukee Brewers", "Kansas City Royals"))
+            self.assertIsInstance(p["entry_price"], float)
+
+    def test_parse_confidence_helper(self):
+        self.assertEqual(
+            parse_confidence("foo confidence=0.55 (low) bar"),
+            {"score": 0.55, "label": "low"},
+        )
+        self.assertIsNone(parse_confidence("no marker here"))
+        self.assertIsNone(parse_confidence(None))
+
+    # ---- closed positions are the exit feed, newest first ----
+    def test_closed_positions_sorted_desc_by_exit_ts(self):
+        closed = self.state["closed_positions"]
+        self.assertEqual(len(closed), 4)
+        ts = [c["exit_ts_utc"] for c in closed]
+        self.assertEqual(ts, [EXIT_T4, EXIT_T3, EXIT_T2, EXIT_T1])
+        # Newest item is the resolution loss; carries its normalized reason.
+        self.assertEqual(closed[0]["reason"], "lost")
+        self.assertAlmostEqual(closed[0]["realized_pnl_usd"], -100.0, places=6)
+
+    # ---- title cleaning falls back to a short market id ----
+    def test_clean_title_shortens_hex_market_id(self):
+        title = clean_title(notes="no title here", market_id="0x" + "c" * 60)
+        self.assertIn("…", title)
+        self.assertTrue(title.startswith("0x"))
+        # An explicit title= marker in notes wins.
+        self.assertEqual(
+            clean_title(notes="x; title=Some Market; y", market_id="0xabc"),
+            "Some Market",
+        )
+
+    # ---- robustness: empty ledger yields a sane empty state ----
+    def test_empty_ledger_is_safe(self):
+        fd, empty_path = tempfile.mkstemp(suffix=".jsonl")
+        os.close(fd)
+        try:
+            state = build_state(PnlLedger(empty_path), bankroll_usd=BANKROLL)
+            self.assertEqual(state["summary"]["n_open"], 0)
+            self.assertEqual(state["summary"]["n_settled"], 0)
+            self.assertEqual(state["open_positions"], [])
+            self.assertEqual(state["closed_positions"], [])
+            self.assertEqual(state["exit_mix"], {})
+            # Only the start point on the curve.
+            self.assertEqual(len(state["equity_curve"]), 1)
+            self.assertAlmostEqual(
+                state["equity_curve"][0]["equity"], BANKROLL, places=6
+            )
+        finally:
+            os.remove(empty_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/prediction_market_scanner/test_exit_backtest.py
+++ b/tests/prediction_market_scanner/test_exit_backtest.py
@@ -1,0 +1,287 @@
+"""Tests for src/exit_backtest.py (PURE — no network, no orders).
+
+The module is a pure exit-overlay backtester: every function is a computation over
+numbers the test supplies, so there is no client/session/ledger to fake. We assert:
+
+  * simulate_exit:
+      - a path that DIPS past the stop-loss exits at the stop (capped loss, strictly
+        better than riding to $0);
+      - a path that RISES to a take_profit_price exits with a gain;
+      - a flat path with no trigger HOLDS to final_price (won -> positive at
+        entry < 1; lost -> ~ -1, the whole stake);
+      - when a single price would trip BOTH stop-loss and take-profit, stop-loss
+        wins (capital-preserving ordering);
+      - entry_price <= 0 -> ('skip');
+      - the exact return_on_cost math (entry 0.5, exit 0.3, 200 bps -> -0.412;
+        exit 1.0 won -> +0.96).
+  * grid_search:
+      - combos are ranked by mean_return descending;
+      - the baseline (all-None hold-to-resolution) combo is always present;
+      - the risk_adjusted pick excludes any combo whose worst_return < -0.6;
+      - each combo's exit_mix counts sum to its n.
+
+PURE: there is no order/sign/redeem/web3/network surface anywhere in the module
+under test — these tests need no I/O of any kind.
+"""
+
+from __future__ import annotations
+
+import math
+import unittest
+
+import exit_backtest
+from exit_backtest import grid_search, simulate_exit
+
+
+class SimulateExitTest(unittest.TestCase):
+    def test_stop_loss_caps_the_loss_below_riding_to_zero(self):
+        # Entry 0.50; price dips to 0.30 (r = -0.40) then would recover. A 30% stop
+        # fires at 0.30 BEFORE the recovery, and the capped loss beats riding to $0.
+        ret, reason = simulate_exit(
+            0.50,
+            [0.40, 0.30, 0.45],
+            0.0,
+            stop_loss_pct=0.30,
+            take_profit_pct=None,
+            take_profit_price=None,
+        )
+        self.assertEqual(reason, "stop_loss")
+        # Exit at 0.30: (1/0.5)*0.30*0.98 - 1 = -0.412.
+        self.assertAlmostEqual(ret, -0.412, places=6)
+        # Riding to resolution at $0 would be a full -1.0 loss; the stop is better.
+        ride, ride_reason = simulate_exit(
+            0.50,
+            [0.40, 0.30, 0.45],
+            0.0,
+            stop_loss_pct=None,
+            take_profit_pct=None,
+            take_profit_price=None,
+        )
+        self.assertEqual(ride_reason, "resolution")
+        self.assertAlmostEqual(ride, -1.0, places=6)
+        self.assertGreater(ret, ride)
+
+    def test_take_profit_price_exits_with_a_gain(self):
+        # Entry 0.50; rises to 0.90 which hits the absolute take-profit target.
+        ret, reason = simulate_exit(
+            0.50,
+            [0.60, 0.90, 0.95],
+            1.0,
+            stop_loss_pct=None,
+            take_profit_pct=None,
+            take_profit_price=0.90,
+        )
+        self.assertEqual(reason, "take_profit")
+        # Exit at 0.90: (1/0.5)*0.90*0.98 - 1 = 0.764 > 0.
+        self.assertAlmostEqual(ret, 0.764, places=6)
+        self.assertGreater(ret, 0.0)
+
+    def test_take_profit_pct_exits_when_relative_target_hit(self):
+        # Entry 0.40; rises to 0.65 -> r = +0.625 clears a 0.5 take_profit_pct.
+        # (0.60 would give r = 0.4999999999999998 in binary float — just shy of the
+        # threshold — so use a price that genuinely exceeds +50%.)
+        ret, reason = simulate_exit(
+            0.40,
+            [0.45, 0.65, 0.50],
+            0.0,
+            stop_loss_pct=None,
+            take_profit_pct=0.50,
+            take_profit_price=None,
+        )
+        self.assertEqual(reason, "take_profit")
+        self.assertAlmostEqual(ret, (1.0 / 0.40) * 0.65 * 0.98 - 1.0, places=6)
+
+    def test_flat_path_holds_to_resolution_won_is_positive(self):
+        # No trigger across a flat path; entry 0.50 won -> +0.96.
+        ret, reason = simulate_exit(
+            0.50,
+            [0.50, 0.51, 0.49],
+            1.0,
+            stop_loss_pct=0.90,
+            take_profit_pct=None,
+            take_profit_price=0.99,
+        )
+        self.assertEqual(reason, "resolution")
+        self.assertAlmostEqual(ret, 0.96, places=6)
+        self.assertGreater(ret, 0.0)
+
+    def test_flat_path_holds_to_resolution_lost_is_near_minus_one(self):
+        # No trigger; entry 0.50 lost -> exit at 0.0 -> -1.0 (the whole stake).
+        ret, reason = simulate_exit(
+            0.50,
+            [0.50, 0.48, 0.52],
+            0.0,
+            stop_loss_pct=None,
+            take_profit_pct=2.0,
+            take_profit_price=None,
+        )
+        self.assertEqual(reason, "resolution")
+        self.assertAlmostEqual(ret, -1.0, places=6)
+
+    def test_stop_loss_checked_before_take_profit_at_same_point(self):
+        # Construct a single price that would trip BOTH a stop and a take-profit if
+        # both were checked: stop_loss_pct=0.0 (any r<=0 trips) AND
+        # take_profit_pct=0.0 (any r>=0 trips). At the FIRST price r==0 satisfies
+        # both; stop-loss must win.
+        ret, reason = simulate_exit(
+            0.50,
+            [0.50],
+            1.0,
+            stop_loss_pct=0.0,
+            take_profit_pct=0.0,
+            take_profit_price=0.10,
+        )
+        self.assertEqual(reason, "stop_loss")
+        # Exit at the entry price 0.50: (1/0.5)*0.5*0.98 - 1 = -0.02 (just the fee).
+        self.assertAlmostEqual(ret, -0.02, places=6)
+
+    def test_entry_price_zero_returns_skip(self):
+        ret, reason = simulate_exit(
+            0.0,
+            [0.5, 0.6],
+            1.0,
+            stop_loss_pct=0.3,
+            take_profit_pct=0.5,
+            take_profit_price=0.9,
+        )
+        self.assertEqual(reason, "skip")
+        self.assertEqual(ret, 0.0)
+
+    def test_return_on_cost_math_loss_and_win(self):
+        # Spec-pinned arithmetic. Loss: entry 0.5, exit 0.3, 200 bps.
+        self.assertAlmostEqual(
+            exit_backtest._return_on_cost(0.5, 0.3, 200.0), -0.412, places=6
+        )
+        # Win: entry 0.5, exit 1.0, 200 bps.
+        self.assertAlmostEqual(
+            exit_backtest._return_on_cost(0.5, 1.0, 200.0), 0.96, places=6
+        )
+
+    def test_out_of_range_prices_are_skipped_not_acted_on(self):
+        # A bogus 1.5 price (out of [0,1]) must NOT trip the take-profit; the valid
+        # 0.90 that follows does.
+        ret, reason = simulate_exit(
+            0.50,
+            [1.5, 0.90],
+            1.0,
+            stop_loss_pct=None,
+            take_profit_pct=None,
+            take_profit_price=0.85,
+        )
+        self.assertEqual(reason, "take_profit")
+        self.assertAlmostEqual(ret, (1.0 / 0.5) * 0.90 * 0.98 - 1.0, places=6)
+
+
+class GridSearchTest(unittest.TestCase):
+    def _samples(self):
+        # Two winners (rose then resolved at 1.0) and two losers (dipped through a
+        # 35c level — r = -0.30, which a 0.30 stop catches with a capped loss of
+        # -0.314, above the -0.6 floor — then on to 0.0). Entry 0.50 throughout.
+        return [
+            {"entry_price": 0.50, "price_path": [0.60, 0.95], "final_price": 1.0},
+            {"entry_price": 0.50, "price_path": [0.70, 0.92], "final_price": 1.0},
+            {"entry_price": 0.50, "price_path": [0.35, 0.20], "final_price": 0.0},
+            {"entry_price": 0.50, "price_path": [0.35, 0.10], "final_price": 0.0},
+        ]
+
+    def test_combos_ranked_by_mean_return_desc(self):
+        res = grid_search(
+            self._samples(),
+            sl_values=[None, 0.3, 0.5],
+            tp_pct_values=[None, 0.5],
+            tp_price_values=[None, 0.90],
+        )
+        means = [c["mean_return"] for c in res["combos"]]
+        self.assertEqual(means, sorted(means, reverse=True))
+        self.assertIs(res["best_by_meanret"], res["combos"][0])
+
+    def test_baseline_all_none_present(self):
+        res = grid_search(
+            self._samples(),
+            # Deliberately OMIT None on every axis; baseline must still be injected.
+            sl_values=[0.3, 0.5],
+            tp_pct_values=[0.5],
+            tp_price_values=[0.90],
+        )
+        baselines = [
+            c
+            for c in res["combos"]
+            if c["stop_loss_pct"] is None
+            and c["take_profit_pct"] is None
+            and c["take_profit_price"] is None
+        ]
+        self.assertEqual(len(baselines), 1)
+        self.assertIsNotNone(res["baseline"])
+        # Baseline holds to resolution: 2 wins (+0.96 each) + 2 losses (-1.0 each).
+        self.assertEqual(res["baseline"]["exit_mix"], {"resolution": 4})
+        self.assertAlmostEqual(
+            res["baseline"]["mean_return"], (0.96 + 0.96 - 1.0 - 1.0) / 4, places=6
+        )
+
+    def test_risk_adjusted_excludes_combos_below_worst_floor(self):
+        res = grid_search(
+            self._samples(),
+            sl_values=[None, 0.3, 0.5],
+            tp_pct_values=[None, 0.5],
+            tp_price_values=[None, 0.90],
+        )
+        ra = res["risk_adjusted"]
+        self.assertIsNotNone(ra)
+        # The pick must respect the -0.6 worst-single-trade floor...
+        self.assertGreaterEqual(ra["worst_return"], exit_backtest.RISK_ADJUSTED_WORST_FLOOR)
+        # ...and be the highest mean_return among all eligible combos.
+        eligible = [
+            c
+            for c in res["combos"]
+            if c["worst_return"] >= exit_backtest.RISK_ADJUSTED_WORST_FLOOR
+        ]
+        self.assertTrue(eligible)
+        self.assertAlmostEqual(
+            ra["mean_return"], max(c["mean_return"] for c in eligible), places=12
+        )
+        # The baseline rides losers to -1.0, which is below the floor -> ineligible.
+        self.assertLess(res["baseline"]["worst_return"], exit_backtest.RISK_ADJUSTED_WORST_FLOOR)
+
+    def test_risk_adjusted_none_when_no_combo_clears_floor(self):
+        # All-loser dataset with no stop available: every combo rides to -1.0.
+        samples = [
+            {"entry_price": 0.50, "price_path": [0.40, 0.20], "final_price": 0.0},
+            {"entry_price": 0.50, "price_path": [0.30, 0.10], "final_price": 0.0},
+        ]
+        res = grid_search(
+            samples,
+            sl_values=[None],
+            tp_pct_values=[None],
+            tp_price_values=[None],
+        )
+        self.assertIsNone(res["risk_adjusted"])
+
+    def test_exit_mix_counts_sum_to_n(self):
+        res = grid_search(
+            self._samples(),
+            sl_values=[None, 0.3, 0.5],
+            tp_pct_values=[None, 0.5],
+            tp_price_values=[None, 0.90],
+        )
+        for combo in res["combos"]:
+            self.assertEqual(sum(combo["exit_mix"].values()), combo["n"])
+
+    def test_skipped_unsizable_samples_excluded_from_n(self):
+        # One sample has entry 0 -> simulate_exit returns 'skip' -> dropped from n.
+        samples = [
+            {"entry_price": 0.50, "price_path": [0.60, 0.95], "final_price": 1.0},
+            {"entry_price": 0.0, "price_path": [0.60, 0.95], "final_price": 1.0},
+        ]
+        res = grid_search(
+            samples,
+            sl_values=[None],
+            tp_pct_values=[None],
+            tp_price_values=[None],
+        )
+        baseline = res["baseline"]
+        self.assertEqual(baseline["n"], 1)
+        self.assertEqual(sum(baseline["exit_mix"].values()), 1)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/prediction_market_scanner/test_exit_rules.py
+++ b/tests/prediction_market_scanner/test_exit_rules.py
@@ -1,0 +1,399 @@
+"""Tests for src/exit_rules.py (SHADOW-ONLY).
+
+No network. ``apply_exit_rules`` is driven with an injected fake ``price_fn`` and
+a real tempfile :class:`PnlLedger` carrying open records (entry_price > 0). We
+assert:
+
+  * evaluate_exit: a position past the stop-loss reads 'stop_loss', past a
+    take-profit pct or price reads 'take_profit', a small move holds (None), an
+    unpriced/None/out-of-range mark holds, and stop-loss is checked BEFORE
+    take-profit;
+  * compute_exit_pnl: a losing exit is negative but capped well above -size (the
+    whole point — we recover most of the stake instead of riding to $0), a
+    winning exit is positive, and an unsizable position returns 0.0;
+  * apply_exit_rules settles a stop-loss position at the current mark with the
+    capped (smaller) loss, settles a take-profit position with a gain, leaves an
+    in-between position open, leaves a None-mark position open, and a price_fn
+    that RAISES for one position does not abort the sweep of the others.
+
+SHADOW-ONLY: exit rules are pure ledger bookkeeping over the current observable
+mark — there is no order/execution surface anywhere in the module under test.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from typing import Any, Dict, List, Optional
+
+import exit_rules
+from exit_rules import apply_exit_rules, compute_exit_pnl, evaluate_exit
+from state.pnl_ledger import PnlLedger, TradeRecord
+
+
+# Exit timestamps comfortably AFTER every record's entry ts below, so the
+# ledger's no-look-ahead guard is satisfied (exit_ts >= entry ts).
+ENTRY_TS = "2026-06-01T12:00:00+00:00"
+EXIT_TS = "2026-06-02T12:00:00+00:00"
+
+
+def _open_record(
+    *,
+    trade_id: str,
+    market_id: str = "0xCOND",
+    side: str = "Yes",
+    entry_price: float = 0.50,
+    size: float = 100.0,
+    ts_utc: str = ENTRY_TS,
+) -> TradeRecord:
+    """An OPEN whale_convergence record (entry priced for exit math)."""
+    return TradeRecord(
+        trade_id=trade_id,
+        ts_utc=ts_utc,
+        venue="polymarket",
+        market_id=market_id,
+        side=side,
+        entry_price=entry_price,
+        size=size,
+        fees_usd=0.0,
+        slippage_bps=0.0,
+        strategy="whale_convergence",
+        status="open",
+        notes=(
+            "SHADOW MODE - NO ORDERS; whale_convergence n=3 "
+            "outcomeIndex=0; entry_price=0.5000; wallets=0xT1,0xT2,0xT3"
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# evaluate_exit
+# ---------------------------------------------------------------------------
+
+
+class EvaluateExitTest(unittest.TestCase):
+    def test_down_45pct_triggers_stop_loss(self) -> None:
+        # entry 0.50 -> 0.275 is -45% on cost; stop at 40% -> exit.
+        reason = evaluate_exit(
+            0.50, 0.275,
+            stop_loss_pct=0.40, take_profit_pct=0.50, take_profit_price=0.90,
+        )
+        self.assertEqual(reason, "stop_loss")
+
+    def test_up_60pct_triggers_take_profit_pct(self) -> None:
+        # entry 0.50 -> 0.80 is +60% on cost; tp pct 50% -> exit.
+        reason = evaluate_exit(
+            0.50, 0.80,
+            stop_loss_pct=0.40, take_profit_pct=0.50, take_profit_price=None,
+        )
+        self.assertEqual(reason, "take_profit")
+
+    def test_price_above_take_profit_price_triggers(self) -> None:
+        # current 0.92 >= tp price 0.90 -> exit, even though +/- pct don't fire.
+        reason = evaluate_exit(
+            0.90, 0.92,
+            stop_loss_pct=0.40, take_profit_pct=0.50, take_profit_price=0.90,
+        )
+        self.assertEqual(reason, "take_profit")
+
+    def test_small_move_holds(self) -> None:
+        # entry 0.50 -> 0.52 is +4%: below tp, above stop -> hold.
+        reason = evaluate_exit(
+            0.50, 0.52,
+            stop_loss_pct=0.40, take_profit_pct=0.50, take_profit_price=0.90,
+        )
+        self.assertIsNone(reason)
+
+    def test_zero_entry_price_holds(self) -> None:
+        self.assertIsNone(
+            evaluate_exit(
+                0.0, 0.30,
+                stop_loss_pct=0.40, take_profit_pct=0.50, take_profit_price=0.90,
+            )
+        )
+
+    def test_none_or_out_of_range_mark_holds(self) -> None:
+        for bad in (None, -0.1, 1.5, "0.3", True):
+            self.assertIsNone(
+                evaluate_exit(
+                    0.50, bad,
+                    stop_loss_pct=0.40, take_profit_pct=0.50,
+                    take_profit_price=0.90,
+                ),
+                msg=f"mark {bad!r} should hold",
+            )
+
+    def test_stop_loss_checked_before_take_profit(self) -> None:
+        # A degenerate case where BOTH could nominally fire: price is past the
+        # absolute take-profit price AND past the stop-loss on return-on-cost.
+        # With entry 0.95 and current 0.91: r = 0.91/0.95 - 1 = -0.042 (NOT a
+        # stop). To force the both-true case, use a stop_loss_pct of 0.01 and a
+        # take_profit_price of 0.90: r = -0.042 <= -0.01 -> stop fires first.
+        reason = evaluate_exit(
+            0.95, 0.91,
+            stop_loss_pct=0.01, take_profit_pct=None, take_profit_price=0.90,
+        )
+        self.assertEqual(reason, "stop_loss")
+
+    def test_disabled_legs_hold(self) -> None:
+        # All thresholds None -> always hold regardless of move.
+        self.assertIsNone(
+            evaluate_exit(
+                0.50, 0.05,
+                stop_loss_pct=None, take_profit_pct=None, take_profit_price=None,
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# compute_exit_pnl
+# ---------------------------------------------------------------------------
+
+
+class ComputeExitPnlTest(unittest.TestCase):
+    def test_losing_exit_negative_but_capped_above_full_loss(self) -> None:
+        # entry 0.5, size 100 -> 200 units; sell at 0.3 -> gross $60, net ~$58.8;
+        # PnL ~ -41.2. Negative, but FAR above the -100 a ride-to-$0 would cost.
+        pnl = compute_exit_pnl(0.5, 100.0, 0.3)
+        self.assertLess(pnl, 0.0)
+        self.assertGreater(pnl, -100.0)
+        # ~ -40 net of fee (60 gross * 0.98 = 58.8; 58.8 - 100 = -41.2).
+        self.assertAlmostEqual(pnl, -41.2, places=4)
+
+    def test_winning_exit_positive(self) -> None:
+        # entry 0.5, size 100 -> 200 units; sell at 0.8 -> gross $160, net $156.8;
+        # PnL = +56.8.
+        pnl = compute_exit_pnl(0.5, 100.0, 0.8)
+        self.assertGreater(pnl, 0.0)
+        self.assertAlmostEqual(pnl, 56.8, places=4)
+
+    def test_zero_entry_or_size_returns_zero(self) -> None:
+        self.assertEqual(compute_exit_pnl(0.0, 100.0, 0.3), 0.0)
+        self.assertEqual(compute_exit_pnl(0.5, 0.0, 0.3), 0.0)
+
+    def test_fee_bps_zero_recovers_full_proceeds(self) -> None:
+        # No haircut: entry 0.5, size 100, exit 0.3 -> gross 60, PnL = -40 exactly.
+        self.assertAlmostEqual(
+            compute_exit_pnl(0.5, 100.0, 0.3, fee_bps=0.0), -40.0, places=4
+        )
+
+
+# ---------------------------------------------------------------------------
+# apply_exit_rules: sweep open ledger, settle stop / take-profit at the mark
+# ---------------------------------------------------------------------------
+
+
+class _FakePriceFn:
+    """callable(record) -> mark | None, by trade_id, recording calls.
+
+    A trade_id listed in ``raises_for`` makes the call raise, to prove one bad
+    position does not abort the sweep of the others.
+    """
+
+    def __init__(
+        self,
+        prices: Dict[str, Optional[float]],
+        raises_for: Any = None,
+    ) -> None:
+        self._prices = prices
+        self._raises_for = set(raises_for or ())
+        self.calls: List[str] = []
+
+    def __call__(self, record: Any) -> Optional[float]:
+        self.calls.append(record.trade_id)
+        if record.trade_id in self._raises_for:
+            raise RuntimeError(f"boom for {record.trade_id}")
+        return self._prices.get(record.trade_id)
+
+
+class ApplyExitRulesTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self._tmp.name, "pnl_ledger.jsonl")
+        self.ledger = PnlLedger(self.path)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_stop_loss_settled_at_mark_with_capped_loss(self) -> None:
+        # entry 0.50, current 0.25 -> -50% on cost -> stop fires; settle at 0.25.
+        self.ledger.append(
+            _open_record(trade_id="sl", entry_price=0.50, size=100.0)
+        )
+        price_fn = _FakePriceFn({"sl": 0.25})
+
+        res = apply_exit_rules(
+            self.ledger, price_fn,
+            stop_loss_pct=0.40, take_profit_pct=0.50, take_profit_price=0.90,
+            now_iso=EXIT_TS,
+        )
+
+        self.assertEqual(res["exited"], 1)
+        self.assertEqual(res["stop_loss"], 1)
+        self.assertEqual(res["take_profit"], 0)
+        self.assertEqual(res["still_open"], 0)
+        # Capped loss: ~ -51 (50 gross * 0.98 - 100), NOT the -100 of a $0 ride.
+        self.assertLess(res["realized_pnl_usd"], 0.0)
+        self.assertGreater(res["realized_pnl_usd"], -100.0)
+
+        settled = self.ledger.settled()
+        self.assertEqual(len(settled), 1)
+        rec = settled[0]
+        self.assertEqual(rec.status, "settled")
+        self.assertEqual(rec.exit_price, 0.25)
+        self.assertEqual(rec.market_outcome, "exit:stop_loss")
+        self.assertAlmostEqual(rec.realized_pnl_usd, -51.0, places=4)
+        self.assertEqual(self.ledger.open_positions(), [])
+
+    def test_take_profit_settled_with_gain(self) -> None:
+        # entry 0.50, current 0.80 -> +60% -> take-profit; settle at 0.80.
+        self.ledger.append(
+            _open_record(trade_id="tp", entry_price=0.50, size=100.0)
+        )
+        price_fn = _FakePriceFn({"tp": 0.80})
+
+        res = apply_exit_rules(
+            self.ledger, price_fn,
+            stop_loss_pct=0.40, take_profit_pct=0.50, take_profit_price=0.90,
+            now_iso=EXIT_TS,
+        )
+
+        self.assertEqual(res["exited"], 1)
+        self.assertEqual(res["take_profit"], 1)
+        self.assertEqual(res["stop_loss"], 0)
+        self.assertGreater(res["realized_pnl_usd"], 0.0)
+
+        rec = self.ledger.settled()[0]
+        self.assertEqual(rec.exit_price, 0.80)
+        self.assertEqual(rec.market_outcome, "exit:take_profit")
+        self.assertAlmostEqual(rec.realized_pnl_usd, 56.8, places=4)
+
+    def test_in_between_position_stays_open(self) -> None:
+        # entry 0.50, current 0.55 -> +10%: below tp, above stop -> hold.
+        self.ledger.append(
+            _open_record(trade_id="hold", entry_price=0.50, size=100.0)
+        )
+        price_fn = _FakePriceFn({"hold": 0.55})
+
+        res = apply_exit_rules(
+            self.ledger, price_fn,
+            stop_loss_pct=0.40, take_profit_pct=0.50, take_profit_price=0.90,
+            now_iso=EXIT_TS,
+        )
+
+        self.assertEqual(res["exited"], 0)
+        self.assertEqual(res["still_open"], 1)
+        self.assertEqual(res["realized_pnl_usd"], 0.0)
+        self.assertEqual(len(self.ledger.open_positions()), 1)
+        self.assertEqual(self.ledger.settled(), [])
+
+    def test_none_mark_leaves_open(self) -> None:
+        # price_fn returns None (unmarkable) -> never settle on a guessed price.
+        self.ledger.append(
+            _open_record(trade_id="np", entry_price=0.50, size=100.0)
+        )
+        price_fn = _FakePriceFn({"np": None})
+
+        res = apply_exit_rules(
+            self.ledger, price_fn,
+            stop_loss_pct=0.40, take_profit_pct=0.50, take_profit_price=0.90,
+            now_iso=EXIT_TS,
+        )
+
+        self.assertEqual(res["exited"], 0)
+        self.assertEqual(res["still_open"], 1)
+        self.assertEqual(len(self.ledger.open_positions()), 1)
+        self.assertEqual(self.ledger.settled(), [])
+
+    def test_one_raising_price_fn_does_not_abort_the_sweep(self) -> None:
+        # Three open positions: "bad" raises in price_fn, "sl" stops out, "tp"
+        # takes profit. The bad one is left open; the other two settle.
+        self.ledger.append(
+            _open_record(trade_id="bad", market_id="0xBAD", entry_price=0.50)
+        )
+        self.ledger.append(
+            _open_record(trade_id="sl", market_id="0xSL", entry_price=0.50)
+        )
+        self.ledger.append(
+            _open_record(trade_id="tp", market_id="0xTP", entry_price=0.50)
+        )
+        price_fn = _FakePriceFn(
+            {"sl": 0.25, "tp": 0.80}, raises_for=["bad"]
+        )
+
+        res = apply_exit_rules(
+            self.ledger, price_fn,
+            stop_loss_pct=0.40, take_profit_pct=0.50, take_profit_price=0.90,
+            now_iso=EXIT_TS,
+        )
+
+        self.assertEqual(res["exited"], 2)
+        self.assertEqual(res["stop_loss"], 1)
+        self.assertEqual(res["take_profit"], 1)
+        # bad -> still_open (it raised but did not abort the others).
+        self.assertEqual(res["still_open"], 1)
+        # The bad position WAS attempted (proving the skip, not a silent omission).
+        self.assertIn("bad", price_fn.calls)
+
+        open_ids = {r.trade_id for r in self.ledger.open_positions()}
+        settled_ids = {r.trade_id for r in self.ledger.settled()}
+        self.assertEqual(open_ids, {"bad"})
+        self.assertEqual(settled_ids, {"sl", "tp"})
+
+    def test_no_now_iso_uses_current_utc(self) -> None:
+        # Entry ts in the past so the auto-generated now-ish exit ts passes the
+        # ledger's no-look-ahead guard.
+        self.ledger.append(
+            _open_record(trade_id="sl", entry_price=0.50, size=100.0,
+                         ts_utc="2020-01-01T00:00:00+00:00")
+        )
+        price_fn = _FakePriceFn({"sl": 0.25})
+
+        res = apply_exit_rules(
+            self.ledger, price_fn,
+            stop_loss_pct=0.40, take_profit_pct=0.50, take_profit_price=0.90,
+        )  # now_iso omitted
+        self.assertEqual(res["exited"], 1)
+        self.assertTrue(self.ledger.settled())
+
+    def test_empty_ledger_is_noop(self) -> None:
+        price_fn = _FakePriceFn({})
+        res = apply_exit_rules(
+            self.ledger, price_fn,
+            stop_loss_pct=0.40, take_profit_pct=0.50, take_profit_price=0.90,
+            now_iso=EXIT_TS,
+        )
+        self.assertEqual(
+            res,
+            {
+                "exited": 0,
+                "stop_loss": 0,
+                "take_profit": 0,
+                "still_open": 0,
+                "realized_pnl_usd": 0.0,
+            },
+        )
+        self.assertEqual(price_fn.calls, [])
+
+
+# ---------------------------------------------------------------------------
+# Module-level safety: no order/execution symbols
+# ---------------------------------------------------------------------------
+
+
+class ModuleSafetyTest(unittest.TestCase):
+    def test_module_has_no_order_helpers(self) -> None:
+        for forbidden in (
+            "place_order",
+            "create_order",
+            "submit_order",
+            "sign",
+            "sign_order",
+            "redeem",
+        ):
+            self.assertFalse(hasattr(exit_rules, forbidden))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/prediction_market_scanner/test_open_position_dedup.py
+++ b/tests/prediction_market_scanner/test_open_position_dedup.py
@@ -1,0 +1,281 @@
+"""Tests for open-position deduplication (SHADOW-ONLY).
+
+Two ``whale_follow_runner`` loops writing the SAME ledger can each append an
+``open`` event for the same convergence (each snapshots the open set before the
+other's append lands), leaving DUPLICATE open records for one (market, outcome).
+Left alone those duplicates show twice on the dashboard AND settle twice
+(double-counted realized P/L). This module pins down the fix at every layer:
+
+  * ``dedupe_open_positions`` collapses by ``(market_id, side)``, keeping the
+    EARLIEST entry (the honest decision-time fill);
+  * ``PnlLedger.cancel`` retires a record append-only (dropped from both
+    ``open_positions`` and ``settled``) and survives a reload;
+  * ``settle_resolved_positions`` settles a duplicated position ONCE, never twice;
+  * ``build_state`` shows one card per position and ``n_open`` matches;
+  * ``_heal_duplicate_opens`` cancels the extras and is idempotent;
+  * ``_acquire_ledger_lock`` refuses a second LIVE writer and reclaims a stale lock.
+
+No network, no orders — pure ledger bookkeeping and a fake resolver.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from typing import Any, Dict, List, Optional
+
+import whale_follow_runner as runner
+from dashboard.state import build_state
+from exit_rules import apply_exit_rules
+from shadow_settlement import settle_resolved_positions
+from state.pnl_ledger import (
+    PnlLedger,
+    TradeRecord,
+    dedupe_open_positions,
+    duplicate_open_records,
+)
+
+ENTRY_TS_1 = "2026-06-01T12:00:00+00:00"  # earliest entry (the one to keep)
+ENTRY_TS_2 = "2026-06-01T12:00:00.020000+00:00"  # 20ms later — the racing dup
+SETTLE_TS = "2026-06-02T12:00:00+00:00"
+
+
+def _open(
+    *,
+    trade_id: str,
+    market_id: str = "0xMKT",
+    side: str = "Yes",
+    ts_utc: str = ENTRY_TS_1,
+    entry_price: float = 0.40,
+    outcome_index: int = 0,
+) -> TradeRecord:
+    """An OPEN whale-convergence record with the notes markers the stack reads."""
+    return TradeRecord(
+        trade_id=trade_id,
+        ts_utc=ts_utc,
+        venue="polymarket",
+        market_id=market_id,
+        side=side,
+        entry_price=entry_price,
+        size=100.0,
+        fees_usd=0.0,
+        slippage_bps=0.0,
+        strategy="whale_convergence",
+        status="open",
+        notes=(
+            "SHADOW MODE - NO ORDERS; whale_convergence n=4 "
+            f"confidence=0.90 (high); outcomeIndex={outcome_index}; "
+            "entry_price=0.4000 (latest /trades mark); wallets=0xA,0xB,0xC,0xD"
+        ),
+    )
+
+
+class DedupePureFunctionTests(unittest.TestCase):
+    def test_collapses_by_market_and_side_keeping_earliest(self) -> None:
+        keep = _open(trade_id="t-keep", ts_utc=ENTRY_TS_1, entry_price=0.40)
+        dup = _open(trade_id="t-dup", ts_utc=ENTRY_TS_2, entry_price=0.55)
+        deduped = dedupe_open_positions([dup, keep])  # input order shouldn't matter
+        self.assertEqual(len(deduped), 1)
+        self.assertEqual(deduped[0].trade_id, "t-keep")  # earliest ts wins
+        self.assertEqual(deduped[0].entry_price, 0.40)
+
+    def test_distinct_positions_are_not_collapsed(self) -> None:
+        a = _open(trade_id="a", market_id="0xMKT", side="Yes")
+        b = _open(trade_id="b", market_id="0xMKT", side="No")  # same market, diff outcome
+        c = _open(trade_id="c", market_id="0xOTHER", side="Yes")
+        deduped = dedupe_open_positions([a, b, c])
+        self.assertEqual({r.trade_id for r in deduped}, {"a", "b", "c"})
+
+    def test_duplicate_open_records_returns_only_the_extras(self) -> None:
+        keep = _open(trade_id="t-keep", ts_utc=ENTRY_TS_1)
+        dup = _open(trade_id="t-dup", ts_utc=ENTRY_TS_2)
+        extras = duplicate_open_records([keep, dup])
+        self.assertEqual([r.trade_id for r in extras], ["t-dup"])
+
+    def test_empty_and_singleton(self) -> None:
+        self.assertEqual(dedupe_open_positions([]), [])
+        one = _open(trade_id="only")
+        self.assertEqual([r.trade_id for r in dedupe_open_positions([one])], ["only"])
+
+
+class LedgerCancelTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._dir = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self._dir.name, "ledger.jsonl")
+
+    def tearDown(self) -> None:
+        self._dir.cleanup()
+
+    def test_cancel_drops_from_open_and_settled_and_persists(self) -> None:
+        ledger = PnlLedger(self.path)
+        ledger.append(_open(trade_id="t-keep", ts_utc=ENTRY_TS_1))
+        ledger.append(_open(trade_id="t-dup", ts_utc=ENTRY_TS_2))
+        self.assertEqual(len(ledger.open_positions()), 2)
+
+        rec = ledger.cancel("t-dup", reason="duplicate_open")
+        self.assertEqual(rec.status, "cancelled")
+
+        open_ids = {r.trade_id for r in ledger.open_positions()}
+        self.assertEqual(open_ids, {"t-keep"})
+        self.assertNotIn("t-dup", {r.trade_id for r in ledger.settled()})
+
+        # Survives a reload (the cancel is a real append-only event).
+        reloaded = PnlLedger(self.path)
+        self.assertEqual({r.trade_id for r in reloaded.open_positions()}, {"t-keep"})
+
+    def test_cancel_unknown_trade_raises(self) -> None:
+        ledger = PnlLedger(self.path)
+        with self.assertRaises(KeyError):
+            ledger.cancel("nope")
+
+    def test_unique_open_positions_collapses(self) -> None:
+        ledger = PnlLedger(self.path)
+        ledger.append(_open(trade_id="t-keep", ts_utc=ENTRY_TS_1))
+        ledger.append(_open(trade_id="t-dup", ts_utc=ENTRY_TS_2))
+        uniq = ledger.unique_open_positions()
+        self.assertEqual(len(uniq), 1)
+        self.assertEqual(uniq[0].trade_id, "t-keep")
+
+
+class _Resolver:
+    """A fake resolver: every market is closed with token[0] the winner."""
+
+    def __init__(self) -> None:
+        self.calls: List[str] = []
+
+    def __call__(self, market_id: str) -> Optional[Dict[str, Any]]:
+        self.calls.append(market_id)
+        return {
+            "closed": True,
+            "tokens": [
+                {"outcome": "Yes", "winner": True, "price": 1.0},
+                {"outcome": "No", "winner": False, "price": 0.0},
+            ],
+        }
+
+
+class SettlementDoesNotDoubleCountTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._dir = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self._dir.name, "ledger.jsonl")
+
+    def tearDown(self) -> None:
+        self._dir.cleanup()
+
+    def test_duplicate_open_settles_exactly_once(self) -> None:
+        ledger = PnlLedger(self.path)
+        ledger.append(_open(trade_id="t-keep", ts_utc=ENTRY_TS_1, entry_price=0.40))
+        ledger.append(_open(trade_id="t-dup", ts_utc=ENTRY_TS_2, entry_price=0.40))
+
+        resolver = _Resolver()
+        counts = settle_resolved_positions(ledger, resolver, now_iso=SETTLE_TS)
+
+        # Only ONE of the two duplicate records is settled — the P/L is booked once.
+        self.assertEqual(counts["settled"], 1)
+        self.assertEqual(counts["won"], 1)
+        self.assertEqual(len(ledger.settled()), 1)
+        # The realized total equals a single winning position, not two.
+        single = ledger.settled()[0].realized_pnl_usd
+        self.assertAlmostEqual(counts["total_realized_pnl_usd"], single, places=9)
+
+
+class ExitRulesDoNotDoubleExitTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._dir = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self._dir.name, "ledger.jsonl")
+
+    def tearDown(self) -> None:
+        self._dir.cleanup()
+
+    def test_duplicate_open_take_profits_exactly_once(self) -> None:
+        ledger = PnlLedger(self.path)
+        ledger.append(_open(trade_id="t-keep", ts_utc=ENTRY_TS_1, entry_price=0.40))
+        ledger.append(_open(trade_id="t-dup", ts_utc=ENTRY_TS_2, entry_price=0.40))
+
+        # A current mark of 0.96 >= take_profit_price (0.95) → take-profit fires.
+        counts = apply_exit_rules(
+            ledger,
+            lambda record: 0.96,
+            stop_loss_pct=0.20,
+            take_profit_pct=0.30,
+            take_profit_price=0.95,
+            now_iso=SETTLE_TS,
+        )
+        self.assertEqual(counts["take_profit"], 1)  # not 2
+        self.assertEqual(len(ledger.settled()), 1)
+
+
+class BuildStateDedupTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._dir = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self._dir.name, "ledger.jsonl")
+
+    def tearDown(self) -> None:
+        self._dir.cleanup()
+
+    def test_open_cards_and_count_are_deduped(self) -> None:
+        ledger = PnlLedger(self.path)
+        ledger.append(_open(trade_id="t-keep", side="Frances Tiafoe", ts_utc=ENTRY_TS_1))
+        ledger.append(_open(trade_id="t-dup", side="Frances Tiafoe", ts_utc=ENTRY_TS_2))
+        ledger.append(_open(trade_id="t-other", side="Matteo Arnaldi", ts_utc=ENTRY_TS_1))
+
+        state = build_state(ledger, bankroll_usd=1000.0)
+        sides = sorted(p["side"] for p in state["open_positions"])
+        self.assertEqual(sides, ["Frances Tiafoe", "Matteo Arnaldi"])  # dup collapsed
+        self.assertEqual(state["summary"]["n_open"], 2)  # count matches the cards
+
+
+class HealDuplicateOpensTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._dir = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self._dir.name, "ledger.jsonl")
+
+    def tearDown(self) -> None:
+        self._dir.cleanup()
+
+    def test_heal_cancels_extras_and_is_idempotent(self) -> None:
+        ledger = PnlLedger(self.path)
+        ledger.append(_open(trade_id="t-keep", ts_utc=ENTRY_TS_1))
+        ledger.append(_open(trade_id="t-dup", ts_utc=ENTRY_TS_2))
+
+        n = runner._heal_duplicate_opens(ledger)
+        self.assertEqual(n, 1)
+        self.assertEqual({r.trade_id for r in ledger.open_positions()}, {"t-keep"})
+
+        # Running again on a now-clean ledger heals nothing.
+        self.assertEqual(runner._heal_duplicate_opens(ledger), 0)
+
+
+class LedgerLockTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._dir = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self._dir.name, "ledger.jsonl")
+        self._orig_pid_alive = runner._pid_alive
+
+    def tearDown(self) -> None:
+        runner._pid_alive = self._orig_pid_alive
+        self._dir.cleanup()
+
+    def test_refuses_when_a_live_writer_holds_the_lock(self) -> None:
+        lock_path = f"{self.path}.lock"
+        with open(lock_path, "w", encoding="utf-8") as handle:
+            handle.write("999999")  # a different PID
+        runner._pid_alive = lambda pid: True  # pretend it's alive
+        self.assertIsNone(runner._acquire_ledger_lock(self.path))
+
+    def test_reclaims_a_stale_lock(self) -> None:
+        lock_path = f"{self.path}.lock"
+        with open(lock_path, "w", encoding="utf-8") as handle:
+            handle.write("999999")
+        runner._pid_alive = lambda pid: False  # the holder is gone
+        acquired = runner._acquire_ledger_lock(self.path)
+        self.assertEqual(acquired, lock_path)
+        with open(lock_path, "r", encoding="utf-8") as handle:
+            self.assertEqual(handle.read().strip(), str(os.getpid()))
+        runner._release_ledger_lock(acquired)
+        self.assertFalse(os.path.exists(lock_path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/prediction_market_scanner/test_open_position_dedup.py
+++ b/tests/prediction_market_scanner/test_open_position_dedup.py
@@ -28,6 +28,7 @@ from typing import Any, Dict, List, Optional
 import whale_follow_runner as runner
 from dashboard.state import build_state
 from exit_rules import apply_exit_rules
+from portfolio_reporter import build_report
 from shadow_settlement import settle_resolved_positions
 from state.pnl_ledger import (
     PnlLedger,
@@ -224,6 +225,44 @@ class BuildStateDedupTests(unittest.TestCase):
         sides = sorted(p["side"] for p in state["open_positions"])
         self.assertEqual(sides, ["Frances Tiafoe", "Matteo Arnaldi"])  # dup collapsed
         self.assertEqual(state["summary"]["n_open"], 2)  # count matches the cards
+
+
+class PortfolioReportDedupTests(unittest.TestCase):
+    """build_report marks ONE position per (market, outcome) — a duplicate open
+    must not inflate unrealized P/L or equity (the arb runner reports without the
+    runner's self-heal, so build_report has to be correct on its own)."""
+
+    def setUp(self) -> None:
+        self._dir = tempfile.TemporaryDirectory()
+
+    def tearDown(self) -> None:
+        self._dir.cleanup()
+
+    def _ledger(self, name: str) -> PnlLedger:
+        return PnlLedger(os.path.join(self._dir.name, name))
+
+    def test_duplicate_open_does_not_inflate_marked_equity(self) -> None:
+        # A ledger with a duplicate open (same market+outcome).
+        dup = self._ledger("dup.jsonl")
+        dup.append(_open(trade_id="t-keep", ts_utc=ENTRY_TS_1, entry_price=0.40))
+        dup.append(_open(trade_id="t-dup", ts_utc=ENTRY_TS_2, entry_price=0.40))
+        # A ledger with the single true position.
+        single = self._ledger("single.jsonl")
+        single.append(_open(trade_id="t-keep", ts_utc=ENTRY_TS_1, entry_price=0.40))
+
+        price_fn = lambda record: 0.70  # a real mark > entry
+        dup_report = build_report(dup, price_fn=price_fn, bankroll_usd=1000.0)
+        single_report = build_report(single, price_fn=price_fn, bankroll_usd=1000.0)
+
+        self.assertEqual(dup_report["n_open"], 1)
+        self.assertAlmostEqual(
+            dup_report["unrealized_pnl_usd"],
+            single_report["unrealized_pnl_usd"],
+            places=9,
+        )
+        self.assertAlmostEqual(
+            dup_report["equity_usd"], single_report["equity_usd"], places=9
+        )
 
 
 class HealDuplicateOpensTests(unittest.TestCase):

--- a/tests/prediction_market_scanner/test_polymarket_data_api.py
+++ b/tests/prediction_market_scanner/test_polymarket_data_api.py
@@ -16,6 +16,7 @@ import requests
 
 from exchanges.polymarket_data_api import (
     DEFAULT_BASE_URL,
+    DEFAULT_LB_BASE_URL,
     PolymarketDataAPIClient,
     PolymarketDataAPIError,
 )
@@ -152,6 +153,23 @@ def _holders_payload() -> List[dict]:
                     "verified": False,
                 }
             ],
+        },
+    ]
+
+
+def _profit_payload() -> List[dict]:
+    return [
+        {
+            "proxyWallet": "0xWINNER_1",
+            "amount": 1234567.89,
+            "name": "Theo4",
+            "pseudonym": "theo",
+        },
+        {
+            "proxyWallet": "0xWINNER_2",
+            "amount": 98765.43,
+            "name": "WhaleTwo",
+            "pseudonym": "wtwo",
         },
     ]
 
@@ -313,6 +331,82 @@ class ErrorHandlingTest(unittest.TestCase):
         client = _make_client(get_mock)
         with self.assertRaises(PolymarketDataAPIError):
             client.get_trades()
+
+
+# ---------------------------------------------------------------------------
+# get_profit_leaderboard (DIFFERENT host: lb-api)
+# ---------------------------------------------------------------------------
+
+
+class GetProfitLeaderboardTest(unittest.TestCase):
+    def test_parses_profit_list(self) -> None:
+        get_mock = mock.Mock(return_value=_StubResponse(_profit_payload()))
+        client = _make_client(get_mock)
+
+        rows = client.get_profit_leaderboard(window="all", limit=100)
+
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["proxyWallet"], "0xWINNER_1")
+        self.assertEqual(rows[0]["amount"], 1234567.89)
+        self.assertEqual(rows[0]["name"], "Theo4")
+        self.assertEqual(rows[1]["proxyWallet"], "0xWINNER_2")
+
+    def test_hits_lb_host_with_window_and_limit(self) -> None:
+        get_mock = mock.Mock(return_value=_StubResponse(_profit_payload()))
+        client = _make_client(get_mock)
+
+        client.get_profit_leaderboard(window="1d", limit=25)
+
+        args, kwargs = get_mock.call_args
+        # The profit endpoint MUST go to the lb-api host, not the data-api host.
+        self.assertEqual(args[0], f"{DEFAULT_LB_BASE_URL}/profit")
+        self.assertNotEqual(DEFAULT_LB_BASE_URL, DEFAULT_BASE_URL)
+        self.assertEqual(kwargs["params"]["window"], "1d")
+        self.assertEqual(kwargs["params"]["limit"], 25)
+
+    def test_default_window_is_all(self) -> None:
+        get_mock = mock.Mock(return_value=_StubResponse(_profit_payload()))
+        client = _make_client(get_mock)
+        client.get_profit_leaderboard()
+        _, kwargs = get_mock.call_args
+        self.assertEqual(kwargs["params"]["window"], "all")
+        self.assertEqual(kwargs["params"]["limit"], 100)
+
+    def test_bad_window_400_wrapped_with_context(self) -> None:
+        # An unsupported window string returns HTTP 400 -> wrapped, not crashed.
+        get_mock = mock.Mock(return_value=_StubResponse([], status_code=400))
+        client = _make_client(get_mock)
+        with self.assertRaises(PolymarketDataAPIError) as ctx:
+            client.get_profit_leaderboard(window="7d")
+        msg = str(ctx.exception)
+        self.assertIn("get_profit_leaderboard", msg)
+        self.assertIn("7d", msg)  # the offending window is surfaced
+        self.assertIn("400", msg)
+        self.assertIsInstance(ctx.exception.__cause__, requests.HTTPError)
+
+    def test_network_error_wrapped(self) -> None:
+        get_mock = mock.Mock(side_effect=requests.ConnectionError("refused"))
+        client = _make_client(get_mock)
+        with self.assertRaises(PolymarketDataAPIError) as ctx:
+            client.get_profit_leaderboard(window="all")
+        self.assertIn("get_profit_leaderboard", str(ctx.exception))
+        self.assertIsInstance(ctx.exception.__cause__, requests.ConnectionError)
+
+    def test_non_list_payload_yields_empty(self) -> None:
+        get_mock = mock.Mock(return_value=_StubResponse({"error": "nope"}))
+        client = _make_client(get_mock)
+        self.assertEqual(client.get_profit_leaderboard(), [])
+
+    def test_lb_base_url_override(self) -> None:
+        get_mock = mock.Mock(return_value=_StubResponse(_profit_payload()))
+        session = mock.Mock(spec=requests.Session)
+        session.get = get_mock
+        client = PolymarketDataAPIClient(
+            session=session, lb_base_url="https://lb.example.test/"
+        )
+        client.get_profit_leaderboard()
+        args, _ = get_mock.call_args
+        self.assertEqual(args[0], "https://lb.example.test/profit")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/prediction_market_scanner/test_polymarket_market_data.py
+++ b/tests/prediction_market_scanner/test_polymarket_market_data.py
@@ -24,6 +24,7 @@ from exchanges.polymarket_market_data import (
     PolymarketAPIError,
     best_ask,
     best_bid,
+    get_market_resolution,
     get_order_book,
     get_yes_no_best_asks,
 )
@@ -280,6 +281,104 @@ class GetYesNoBestAsksTest(unittest.TestCase):
         market = {"clobTokenIds": json.dumps(["YES", "NO"])}
         with self.assertRaises(PolymarketAPIError):
             get_yes_no_best_asks(market, session=session)
+
+
+# ---------------------------------------------------------------------------
+# get_market_resolution: CLOB /markets/<conditionId> resolution read
+# ---------------------------------------------------------------------------
+
+
+def _market_payload(closed: bool, tokens: Any) -> dict:
+    """A CLOB /markets/<conditionId> shaped payload (subset settlement reads)."""
+    return {
+        "condition_id": "0xCOND",
+        "question": "Will it resolve YES?",
+        "closed": closed,
+        "end_date_iso": "2026-06-01T00:00:00Z",
+        "tokens": tokens,
+    }
+
+
+class GetMarketResolutionTest(unittest.TestCase):
+    def test_parses_closed_market_with_winner_flags(self) -> None:
+        # YES (index 0) won at $1; NO (index 1) lost at $0.
+        payload = _market_payload(
+            closed=True,
+            tokens=[
+                {"token_id": "111", "outcome": "Yes", "price": "1", "winner": True},
+                {"token_id": "222", "outcome": "No", "price": "0", "winner": False},
+            ],
+        )
+        get_mock = mock.Mock(return_value=_StubResponse(payload))
+        session = _make_session(get_mock)
+
+        res = get_market_resolution("0xCOND", session=session)
+        self.assertIsNotNone(res)
+        self.assertTrue(res["closed"])
+        self.assertEqual(len(res["tokens"]), 2)
+
+        yes, no = res["tokens"]
+        self.assertEqual(yes["outcome"], "Yes")
+        self.assertAlmostEqual(yes["price"], 1.0)
+        self.assertIs(yes["winner"], True)
+        self.assertAlmostEqual(no["price"], 0.0)
+        self.assertIs(no["winner"], False)
+
+        # It hit /markets/<conditionId> (token list ordered to match outcomeIndex).
+        args, _kwargs = get_mock.call_args
+        self.assertTrue(args[0].endswith("/markets/0xCOND"))
+
+    def test_open_market_reports_closed_false(self) -> None:
+        payload = _market_payload(
+            closed=False,
+            tokens=[
+                {"outcome": "Yes", "price": "0.62", "winner": False},
+                {"outcome": "No", "price": "0.38", "winner": False},
+            ],
+        )
+        get_mock = mock.Mock(return_value=_StubResponse(payload))
+        session = _make_session(get_mock)
+
+        res = get_market_resolution("0xCOND", session=session)
+        self.assertIsNotNone(res)
+        self.assertFalse(res["closed"])
+        # Prices still normalized to float even while open.
+        self.assertAlmostEqual(res["tokens"][0]["price"], 0.62)
+
+    def test_empty_condition_id_returns_none_without_call(self) -> None:
+        get_mock = mock.Mock(return_value=_StubResponse(_market_payload(True, [])))
+        session = _make_session(get_mock)
+        self.assertIsNone(get_market_resolution("", session=session))
+        get_mock.assert_not_called()
+
+    def test_http_error_returns_none_not_raise(self) -> None:
+        get_mock = mock.Mock(return_value=_StubResponse({}, status_code=500))
+        session = _make_session(get_mock)
+        # Settlement degrades gracefully: HTTP error -> None, never raises.
+        self.assertIsNone(get_market_resolution("0xCOND", session=session))
+
+    def test_network_error_returns_none_not_raise(self) -> None:
+        get_mock = mock.Mock(side_effect=requests.ConnectionError("refused"))
+        session = _make_session(get_mock)
+        self.assertIsNone(get_market_resolution("0xCOND", session=session))
+
+    def test_non_json_body_returns_none(self) -> None:
+        get_mock = mock.Mock(
+            return_value=_StubResponse(raise_on_json=ValueError("no json"))
+        )
+        session = _make_session(get_mock)
+        self.assertIsNone(get_market_resolution("0xCOND", session=session))
+
+    def test_non_dict_payload_returns_none(self) -> None:
+        get_mock = mock.Mock(return_value=_StubResponse(["not", "a", "dict"]))
+        session = _make_session(get_mock)
+        self.assertIsNone(get_market_resolution("0xCOND", session=session))
+
+    def test_missing_tokens_returns_none(self) -> None:
+        payload = {"condition_id": "0xCOND", "closed": True}  # no tokens key
+        get_mock = mock.Mock(return_value=_StubResponse(payload))
+        session = _make_session(get_mock)
+        self.assertIsNone(get_market_resolution("0xCOND", session=session))
 
 
 if __name__ == "__main__":

--- a/tests/prediction_market_scanner/test_portfolio_reporter.py
+++ b/tests/prediction_market_scanner/test_portfolio_reporter.py
@@ -58,9 +58,13 @@ class BuildReportTest(unittest.TestCase):
     def _ledger(self):
         d = tempfile.mkdtemp()
         led = PnlLedger(str(Path(d) / "ledger.jsonl"))
-        led.append(_rec("a", "YES", 0.50, 100.0, fees_usd=1.0))   # markable
-        led.append(_rec("b", "YES", 0.40, 100.0, fees_usd=0.0))   # pending
-        led.append(_rec("c", "YES", 0.50, 100.0, status="open"))  # to settle
+        # Distinct markets: 'a' and 'b' are SEPARATE positions, not the same
+        # (market, outcome). build_report dedups open positions by (market_id,
+        # side) — two opens sharing that key are treated as one (a duplicate from
+        # racing writers) — so distinct positions must use distinct markets.
+        led.append(_rec("a", "YES", 0.50, 100.0, fees_usd=1.0, market_id="m1"))  # markable
+        led.append(_rec("b", "YES", 0.40, 100.0, fees_usd=0.0, market_id="m2"))  # pending
+        led.append(_rec("c", "YES", 0.50, 100.0, status="open", market_id="m3"))  # to settle
         led.settle("c", exit_price=1.0, exit_ts_utc="2026-06-02T00:00:00+00:00",
                    market_outcome="Yes", realized_pnl_usd=25.0)
         return led

--- a/tests/prediction_market_scanner/test_shadow_settlement.py
+++ b/tests/prediction_market_scanner/test_shadow_settlement.py
@@ -1,0 +1,402 @@
+"""Tests for src/shadow_settlement.py (SHADOW-ONLY).
+
+No network. ``settle_resolved_positions`` is driven with an injected fake
+``resolver`` callable and a real tempfile :class:`PnlLedger` carrying open
+records (entry_price > 0, notes with ``outcomeIndex=N``). We assert:
+
+  * compute_settlement_pnl: a win nets less than the staked notional (the ~2%
+    settlement fee bites the gross payout), a loss returns ``-size``, and an
+    unsizable entry (entry_price 0) returns 0.0;
+  * settle_resolved_positions closes a resolved+won position with a positive
+    realized PnL and a resolved+lost position at ``-size``, leaves an OPEN
+    (closed=false) market open, leaves a resolver-returns-None market open,
+    skips an unpriced (entry_price<=0) position, and a resolver that RAISES for
+    one market does not abort settling the others;
+  * the ledger reflects the settlements (``settled()`` / ``summary()``), and the
+    no-look-ahead guard is respected (``now_iso`` is AFTER each entry ts).
+
+SHADOW-ONLY: settlement is pure ledger bookkeeping — there is no order/execution
+surface anywhere in the module under test.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from typing import Any, Dict, List, Optional
+
+import shadow_settlement
+from shadow_settlement import compute_settlement_pnl, settle_resolved_positions
+from state.pnl_ledger import PnlLedger, TradeRecord
+
+
+# A settlement timestamp comfortably AFTER every record's entry ts below, so the
+# ledger's no-look-ahead guard is satisfied (exit_ts >= entry ts).
+ENTRY_TS = "2026-06-01T12:00:00+00:00"
+SETTLE_TS = "2026-06-02T12:00:00+00:00"
+
+
+def _open_record(
+    *,
+    trade_id: str,
+    market_id: str,
+    outcome_index: int,
+    side: str = "Yes",
+    entry_price: float = 0.50,
+    size: float = 100.0,
+    ts_utc: str = ENTRY_TS,
+) -> TradeRecord:
+    """An OPEN whale_convergence record with an outcomeIndex marker in notes."""
+    return TradeRecord(
+        trade_id=trade_id,
+        ts_utc=ts_utc,
+        venue="polymarket",
+        market_id=market_id,
+        side=side,
+        entry_price=entry_price,
+        size=size,
+        fees_usd=0.0,
+        slippage_bps=0.0,
+        strategy="whale_convergence",
+        status="open",
+        notes=(
+            "SHADOW MODE - NO ORDERS; whale_convergence n=3 "
+            f"outcomeIndex={outcome_index}; entry_price={entry_price:.4f}; "
+            "wallets=0xT1,0xT2,0xT3"
+        ),
+    )
+
+
+def _resolution(closed: bool, winners: List[bool]) -> Dict[str, Any]:
+    """A normalized resolution dict (the shape get_market_resolution returns)."""
+    tokens = [
+        {"outcome": ("Yes" if i == 0 else "No"),
+         "price": (1.0 if w else 0.0),
+         "winner": w}
+        for i, w in enumerate(winners)
+    ]
+    return {"closed": closed, "tokens": tokens}
+
+
+# ---------------------------------------------------------------------------
+# compute_settlement_pnl
+# ---------------------------------------------------------------------------
+
+
+class ComputeSettlementPnlTest(unittest.TestCase):
+    def test_won_is_positive_but_below_notional_due_to_fee(self) -> None:
+        # entry 0.5, size 100 -> units 200; gross $200; net after 2% fee = $196;
+        # PnL = 196 - 100 = 96. Positive and < the +100 a fee-free win would give.
+        pnl = compute_settlement_pnl(0.5, 100.0, won=True)
+        self.assertGreater(pnl, 0.0)
+        self.assertLess(pnl, 100.0)
+        self.assertAlmostEqual(pnl, 96.0, places=4)
+
+    def test_lost_returns_negative_size(self) -> None:
+        self.assertAlmostEqual(
+            compute_settlement_pnl(0.5, 100.0, won=False), -100.0, places=4
+        )
+
+    def test_zero_entry_price_returns_zero(self) -> None:
+        # Unsizable: caller skips rather than fabricate a realized number.
+        self.assertEqual(compute_settlement_pnl(0.0, 100.0, won=True), 0.0)
+        self.assertEqual(compute_settlement_pnl(0.0, 100.0, won=False), 0.0)
+
+    def test_zero_size_returns_zero(self) -> None:
+        self.assertEqual(compute_settlement_pnl(0.5, 0.0, won=True), 0.0)
+
+    def test_fee_bps_zero_recovers_full_payout(self) -> None:
+        # No fee: entry 0.25, size 100 -> units 400, gross $400, PnL = +300.
+        self.assertAlmostEqual(
+            compute_settlement_pnl(0.25, 100.0, won=True, fee_bps=0.0),
+            300.0,
+            places=4,
+        )
+
+    def test_cheap_entry_win_is_large(self) -> None:
+        # entry 0.10, size 100 -> units 1000, gross $1000, net $980, PnL +880.
+        self.assertAlmostEqual(
+            compute_settlement_pnl(0.10, 100.0, won=True), 880.0, places=4
+        )
+
+
+# ---------------------------------------------------------------------------
+# settle_resolved_positions: sweep open ledger, settle resolved markets
+# ---------------------------------------------------------------------------
+
+
+class _FakeResolver:
+    """callable(market_id) -> resolution | None, recording calls.
+
+    A market_id listed in ``raises_for`` makes the call raise, to prove one bad
+    market does not abort the others.
+    """
+
+    def __init__(
+        self,
+        resolutions: Dict[str, Optional[Dict[str, Any]]],
+        raises_for: Any = None,
+    ) -> None:
+        self._resolutions = resolutions
+        self._raises_for = set(raises_for or ())
+        self.calls: List[str] = []
+
+    def __call__(self, market_id: str) -> Optional[Dict[str, Any]]:
+        self.calls.append(market_id)
+        if market_id in self._raises_for:
+            raise RuntimeError(f"boom for {market_id}")
+        return self._resolutions.get(market_id)
+
+
+class SettleResolvedPositionsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self._tmp.name, "pnl_ledger.jsonl")
+        self.ledger = PnlLedger(self.path)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_resolved_win_settled_with_positive_pnl(self) -> None:
+        self.ledger.append(
+            _open_record(trade_id="win", market_id="0xWON", outcome_index=0,
+                         entry_price=0.5, size=100.0)
+        )
+        resolver = _FakeResolver({"0xWON": _resolution(True, [True, False])})
+
+        res = settle_resolved_positions(self.ledger, resolver, now_iso=SETTLE_TS)
+
+        self.assertEqual(res["settled"], 1)
+        self.assertEqual(res["won"], 1)
+        self.assertEqual(res["lost"], 0)
+        self.assertEqual(res["still_open"], 0)
+        self.assertGreater(res["total_realized_pnl_usd"], 0.0)
+        self.assertAlmostEqual(res["total_realized_pnl_usd"], 96.0, places=4)
+
+        # The ledger now shows it settled with the same realized PnL.
+        settled = self.ledger.settled()
+        self.assertEqual(len(settled), 1)
+        rec = settled[0]
+        self.assertEqual(rec.status, "settled")
+        self.assertEqual(rec.exit_price, 1.0)
+        self.assertEqual(rec.market_outcome, "won:Yes")
+        self.assertAlmostEqual(rec.realized_pnl_usd, 96.0, places=4)
+        self.assertEqual(self.ledger.open_positions(), [])
+
+    def test_resolved_loss_settled_at_negative_size(self) -> None:
+        self.ledger.append(
+            _open_record(trade_id="loss", market_id="0xLOST", outcome_index=0,
+                         entry_price=0.5, size=100.0)
+        )
+        # Held outcome (index 0) lost; index 1 won.
+        resolver = _FakeResolver({"0xLOST": _resolution(True, [False, True])})
+
+        res = settle_resolved_positions(self.ledger, resolver, now_iso=SETTLE_TS)
+
+        self.assertEqual(res["settled"], 1)
+        self.assertEqual(res["won"], 0)
+        self.assertEqual(res["lost"], 1)
+        self.assertAlmostEqual(res["total_realized_pnl_usd"], -100.0, places=4)
+
+        rec = self.ledger.settled()[0]
+        self.assertEqual(rec.exit_price, 0.0)
+        self.assertEqual(rec.market_outcome, "lost:Yes")
+        self.assertAlmostEqual(rec.realized_pnl_usd, -100.0, places=4)
+
+    def test_open_market_left_open(self) -> None:
+        self.ledger.append(
+            _open_record(trade_id="still", market_id="0xOPEN", outcome_index=0)
+        )
+        # closed=false -> do NOT settle (no look-ahead on an unresolved book).
+        resolver = _FakeResolver({"0xOPEN": _resolution(False, [False, False])})
+
+        res = settle_resolved_positions(self.ledger, resolver, now_iso=SETTLE_TS)
+
+        self.assertEqual(res["settled"], 0)
+        self.assertEqual(res["still_open"], 1)
+        self.assertEqual(len(self.ledger.open_positions()), 1)
+        self.assertEqual(self.ledger.settled(), [])
+
+    def test_resolver_returns_none_leaves_open(self) -> None:
+        self.ledger.append(
+            _open_record(trade_id="unknown", market_id="0xNONE", outcome_index=0)
+        )
+        resolver = _FakeResolver({"0xNONE": None})
+
+        res = settle_resolved_positions(self.ledger, resolver, now_iso=SETTLE_TS)
+
+        self.assertEqual(res["settled"], 0)
+        self.assertEqual(res["still_open"], 1)
+        self.assertEqual(len(self.ledger.open_positions()), 1)
+
+    def test_unpriced_position_skipped(self) -> None:
+        # entry_price 0.0 (the /holders unmarkable case): cannot compute realized
+        # PnL honestly, so it is counted unpriced and left open.
+        self.ledger.append(
+            _open_record(trade_id="np", market_id="0xWON", outcome_index=0,
+                         entry_price=0.0)
+        )
+        resolver = _FakeResolver({"0xWON": _resolution(True, [True, False])})
+
+        res = settle_resolved_positions(self.ledger, resolver, now_iso=SETTLE_TS)
+
+        self.assertEqual(res["unpriced"], 1)
+        self.assertEqual(res["settled"], 0)
+        self.assertEqual(len(self.ledger.open_positions()), 1)
+        self.assertEqual(self.ledger.settled(), [])
+
+    def test_out_of_range_outcome_index_counted_error(self) -> None:
+        # Notes say outcomeIndex=5 but the resolved market has only 2 tokens.
+        self.ledger.append(
+            _open_record(trade_id="oor", market_id="0xWON", outcome_index=5)
+        )
+        resolver = _FakeResolver({"0xWON": _resolution(True, [True, False])})
+
+        res = settle_resolved_positions(self.ledger, resolver, now_iso=SETTLE_TS)
+
+        self.assertEqual(res["errors"], 1)
+        self.assertEqual(res["settled"], 0)
+        self.assertEqual(len(self.ledger.open_positions()), 1)
+
+    def test_one_raising_resolver_does_not_abort_the_others(self) -> None:
+        # Three open positions: 0xBAD raises, 0xWON wins, 0xLOST loses. The bad
+        # market is counted as an error but the other two still settle.
+        self.ledger.append(
+            _open_record(trade_id="bad", market_id="0xBAD", outcome_index=0)
+        )
+        self.ledger.append(
+            _open_record(trade_id="win", market_id="0xWON", outcome_index=0,
+                         entry_price=0.5, size=100.0)
+        )
+        self.ledger.append(
+            _open_record(trade_id="loss", market_id="0xLOST", outcome_index=0,
+                         entry_price=0.5, size=100.0)
+        )
+        resolver = _FakeResolver(
+            {
+                "0xWON": _resolution(True, [True, False]),
+                "0xLOST": _resolution(True, [False, True]),
+            },
+            raises_for=["0xBAD"],
+        )
+
+        res = settle_resolved_positions(self.ledger, resolver, now_iso=SETTLE_TS)
+
+        self.assertEqual(res["errors"], 1)
+        self.assertEqual(res["settled"], 2)
+        self.assertEqual(res["won"], 1)
+        self.assertEqual(res["lost"], 1)
+        # Net realized = +96 (win) - 100 (loss) = -4.
+        self.assertAlmostEqual(res["total_realized_pnl_usd"], -4.0, places=4)
+
+        # The bad market was attempted (proving the skip, not a silent omission).
+        self.assertIn("0xBAD", resolver.calls)
+        # The bad position stays open; the two good ones are settled.
+        open_ids = {r.trade_id for r in self.ledger.open_positions()}
+        settled_ids = {r.trade_id for r in self.ledger.settled()}
+        self.assertEqual(open_ids, {"bad"})
+        self.assertEqual(settled_ids, {"win", "loss"})
+
+    def test_ledger_summary_reflects_settlements(self) -> None:
+        self.ledger.append(
+            _open_record(trade_id="win", market_id="0xWON", outcome_index=0,
+                         entry_price=0.5, size=100.0)
+        )
+        self.ledger.append(
+            _open_record(trade_id="loss", market_id="0xLOST", outcome_index=0,
+                         entry_price=0.5, size=100.0)
+        )
+        resolver = _FakeResolver(
+            {
+                "0xWON": _resolution(True, [True, False]),
+                "0xLOST": _resolution(True, [False, True]),
+            }
+        )
+
+        settle_resolved_positions(self.ledger, resolver, now_iso=SETTLE_TS)
+
+        summary = self.ledger.summary()
+        self.assertEqual(summary["n_trades"], 2)
+        self.assertEqual(summary["n_settled"], 2)
+        self.assertEqual(summary["n_open"], 0)
+        self.assertAlmostEqual(summary["win_rate"], 0.5)  # 1 win of 2 settled
+        self.assertAlmostEqual(summary["total_realized_pnl_usd"], -4.0, places=4)
+
+    def test_winner_inferred_from_price_when_flag_absent(self) -> None:
+        # Some payloads may carry only a resolved price (no winner flag): a
+        # price >= 0.5 marks the held outcome a winner.
+        self.ledger.append(
+            _open_record(trade_id="pw", market_id="0xPRICE", outcome_index=0,
+                         entry_price=0.5, size=100.0)
+        )
+        resolver = _FakeResolver(
+            {
+                "0xPRICE": {
+                    "closed": True,
+                    "tokens": [
+                        {"outcome": "Yes", "price": 1.0, "winner": False},
+                        {"outcome": "No", "price": 0.0, "winner": False},
+                    ],
+                }
+            }
+        )
+
+        res = settle_resolved_positions(self.ledger, resolver, now_iso=SETTLE_TS)
+
+        self.assertEqual(res["won"], 1)
+        rec = self.ledger.settled()[0]
+        self.assertEqual(rec.market_outcome, "won:Yes")
+
+    def test_no_now_iso_uses_current_utc(self) -> None:
+        # Entry ts in the past so the auto-generated now-ish exit ts passes the
+        # ledger's no-look-ahead guard.
+        self.ledger.append(
+            _open_record(trade_id="win", market_id="0xWON", outcome_index=0,
+                         entry_price=0.5, size=100.0,
+                         ts_utc="2020-01-01T00:00:00+00:00")
+        )
+        resolver = _FakeResolver({"0xWON": _resolution(True, [True, False])})
+
+        res = settle_resolved_positions(self.ledger, resolver)  # now_iso omitted
+        self.assertEqual(res["settled"], 1)
+        self.assertTrue(self.ledger.settled())
+
+    def test_empty_ledger_is_noop(self) -> None:
+        resolver = _FakeResolver({})
+        res = settle_resolved_positions(self.ledger, resolver, now_iso=SETTLE_TS)
+        self.assertEqual(
+            res,
+            {
+                "settled": 0,
+                "won": 0,
+                "lost": 0,
+                "still_open": 0,
+                "unpriced": 0,
+                "errors": 0,
+                "total_realized_pnl_usd": 0.0,
+            },
+        )
+        self.assertEqual(resolver.calls, [])
+
+
+# ---------------------------------------------------------------------------
+# Module-level safety: no order/execution symbols
+# ---------------------------------------------------------------------------
+
+
+class ModuleSafetyTest(unittest.TestCase):
+    def test_module_has_no_order_helpers(self) -> None:
+        for forbidden in (
+            "place_order",
+            "create_order",
+            "submit_order",
+            "sign",
+            "sign_order",
+            "redeem",
+        ):
+            self.assertFalse(hasattr(shadow_settlement, forbidden))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/prediction_market_scanner/test_whale_follow_runner.py
+++ b/tests/prediction_market_scanner/test_whale_follow_runner.py
@@ -22,6 +22,7 @@ from exchanges.polymarket_data_api import PolymarketDataAPIError
 import whale_follow_runner as runner
 from whale_follow_runner import (
     STRATEGY,
+    convergence_from_positions,
     find_convergence,
     make_whale_price_fn,
     run_once,
@@ -453,6 +454,197 @@ class RunOnceMarkEntryTest(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# convergence_from_positions: leaderboard-mode convergence from CURRENT holdings
+# ---------------------------------------------------------------------------
+
+
+def _position(
+    *,
+    condition_id: str,
+    outcome_index: int,
+    outcome: str = "Yes",
+    size: float = 100.0,
+    cur_price: float = 0.55,
+    redeemable: bool = False,
+    realized_pnl: float = 0.0,
+) -> Dict[str, Any]:
+    """A /positions-shaped dict with the fields convergence_from_positions reads.
+
+    Defaults describe a CURRENT OPEN holding (size>0, not redeemable,
+    0<curPrice<1). Override to make it resolved/settled.
+    """
+    return {
+        "proxyWallet": "0xW",
+        "conditionId": condition_id,
+        "outcomeIndex": outcome_index,
+        "outcome": outcome,
+        "size": size,
+        "curPrice": cur_price,
+        "redeemable": redeemable,
+        "realizedPnl": realized_pnl,
+    }
+
+
+class _PositionsFakeClient:
+    """Read-only fake exposing ONLY get_positions(user=...).
+
+    Returns canned positions per wallet; a wallet listed in ``raises_for`` makes
+    get_positions raise (to exercise the per-wallet skip path). No order surface.
+    """
+
+    def __init__(
+        self,
+        positions_by_wallet: Dict[str, List[Dict[str, Any]]],
+        raises_for: Any = None,
+    ) -> None:
+        self._positions_by_wallet = positions_by_wallet
+        self._raises_for = set(raises_for or ())
+        self.positions_calls: List[str] = []
+
+    def get_positions(self, user: str, limit: int = 500) -> List[Dict[str, Any]]:
+        self.positions_calls.append(user)
+        if user in self._raises_for:
+            raise PolymarketDataAPIError(f"boom for {user}")
+        return self._positions_by_wallet.get(user, [])
+
+
+class ConvergenceFromPositionsTest(unittest.TestCase):
+    def test_emits_one_candidate_for_shared_current_holding(self) -> None:
+        # T1 and T2 currently hold the SAME (cond,outcome); T3 holds elsewhere.
+        client = _PositionsFakeClient(
+            {
+                "0xT1": [_position(condition_id="0xCONV", outcome_index=0)],
+                "0xT2": [_position(condition_id="0xCONV", outcome_index=0)],
+                "0xT3": [_position(condition_id="0xOTHER", outcome_index=1,
+                                   outcome="No")],
+            }
+        )
+        cands = convergence_from_positions(
+            client, ["0xT1", "0xT2", "0xT3"], min_convergence=2
+        )
+        self.assertEqual(len(cands), 1)
+        cand = cands[0]
+        self.assertEqual(cand["conditionId"], "0xCONV")
+        self.assertEqual(cand["outcomeIndex"], 0)
+        self.assertEqual(cand["outcome"], "Yes")
+        self.assertEqual(cand["n_target_holders"], 2)
+        self.assertEqual(set(cand["wallets"]), {"0xT1", "0xT2"})
+        # Candidate shape matches find_convergence exactly.
+        self.assertEqual(
+            set(cand),
+            {"conditionId", "outcomeIndex", "outcome", "n_target_holders", "wallets"},
+        )
+
+    def test_resolved_and_redeemable_positions_excluded(self) -> None:
+        # Both wallets "hold" 0xRES idx 0 but each holding is settled, so it
+        # must NOT converge. T1 redeemable; T2 curPrice at the 1.0 boundary.
+        client = _PositionsFakeClient(
+            {
+                "0xT1": [_position(condition_id="0xRES", outcome_index=0,
+                                   redeemable=True)],
+                "0xT2": [_position(condition_id="0xRES", outcome_index=0,
+                                   cur_price=1.0)],
+            }
+        )
+        cands = convergence_from_positions(
+            client, ["0xT1", "0xT2"], min_convergence=2
+        )
+        self.assertEqual(cands, [])
+
+    def test_zero_price_and_zero_size_excluded(self) -> None:
+        client = _PositionsFakeClient(
+            {
+                "0xT1": [_position(condition_id="0xX", outcome_index=0,
+                                   cur_price=0.0)],   # resolved-to-0
+                "0xT2": [_position(condition_id="0xX", outcome_index=0,
+                                   size=0.0)],        # nothing held
+            }
+        )
+        cands = convergence_from_positions(
+            client, ["0xT1", "0xT2"], min_convergence=2
+        )
+        self.assertEqual(cands, [])
+
+    def test_errored_wallet_skipped_others_still_count(self) -> None:
+        # T2 raises; T1 and T3 still converge on the shared holding.
+        client = _PositionsFakeClient(
+            {
+                "0xT1": [_position(condition_id="0xCONV", outcome_index=1,
+                                   outcome="No")],
+                "0xT3": [_position(condition_id="0xCONV", outcome_index=1,
+                                   outcome="No")],
+            },
+            raises_for=["0xT2"],
+        )
+        cands = convergence_from_positions(
+            client, ["0xT1", "0xT2", "0xT3"], min_convergence=2
+        )
+        self.assertEqual(len(cands), 1)
+        self.assertEqual(cands[0]["outcomeIndex"], 1)
+        self.assertEqual(set(cands[0]["wallets"]), {"0xT1", "0xT3"})
+        # The bad wallet WAS attempted (proving the skip, not a silent omission).
+        self.assertIn("0xT2", client.positions_calls)
+
+    def test_distinct_wallet_counted_once_per_market_outcome(self) -> None:
+        # T1 holds the same (cond,outcome) across two position rows -> count 1.
+        client = _PositionsFakeClient(
+            {
+                "0xT1": [
+                    _position(condition_id="0xCONV", outcome_index=0),
+                    _position(condition_id="0xCONV", outcome_index=0),
+                ],
+                "0xT2": [_position(condition_id="0xCONV", outcome_index=0)],
+            }
+        )
+        cands = convergence_from_positions(
+            client, ["0xT1", "0xT2"], min_convergence=2
+        )
+        self.assertEqual(len(cands), 1)
+        self.assertEqual(cands[0]["n_target_holders"], 2)
+
+    def test_below_threshold_not_flagged(self) -> None:
+        client = _PositionsFakeClient(
+            {"0xT1": [_position(condition_id="0xCONV", outcome_index=0)]}
+        )
+        cands = convergence_from_positions(
+            client, ["0xT1"], min_convergence=2
+        )
+        self.assertEqual(cands, [])
+
+    def test_return_stats_yields_winrates_from_same_positions(self) -> None:
+        # T1: 1 settled win + the open converging holding -> win_rate 1.0.
+        # T2: 1 settled loss + the open converging holding -> win_rate 0.0.
+        client = _PositionsFakeClient(
+            {
+                "0xT1": [
+                    _position(condition_id="0xSETTLED", outcome_index=0,
+                              redeemable=True, cur_price=1.0, realized_pnl=50.0),
+                    _position(condition_id="0xCONV", outcome_index=0),
+                ],
+                "0xT2": [
+                    _position(condition_id="0xSETTLED2", outcome_index=1,
+                              redeemable=True, cur_price=0.0, realized_pnl=-20.0),
+                    _position(condition_id="0xCONV", outcome_index=0),
+                ],
+            }
+        )
+        cands, stats = convergence_from_positions(
+            client, ["0xT1", "0xT2"], min_convergence=2, return_stats=True
+        )
+        self.assertEqual(len(cands), 1)
+        self.assertEqual(set(stats), {"0xT1", "0xT2"})
+        self.assertEqual(stats["0xT1"].win_rate, 1.0)
+        self.assertEqual(stats["0xT2"].win_rate, 0.0)
+        # Built from the SAME fetch — exactly one /positions call per wallet.
+        self.assertEqual(sorted(client.positions_calls), ["0xT1", "0xT2"])
+
+    def test_client_has_no_order_method(self) -> None:
+        client = _PositionsFakeClient({})
+        for forbidden in ("place_order", "create_order", "submit_order", "sign", "post"):
+            self.assertFalse(hasattr(client, forbidden))
+
+
+# ---------------------------------------------------------------------------
 # make_whale_price_fn: re-price an open position from its notes marker
 # ---------------------------------------------------------------------------
 
@@ -518,6 +710,172 @@ class ModuleSafetyTest(unittest.TestCase):
     def test_runner_module_has_no_order_helpers(self) -> None:
         for forbidden in ("place_order", "create_order", "submit_order", "sign_order"):
             self.assertFalse(hasattr(runner, forbidden))
+
+
+# ---------------------------------------------------------------------------
+# main(): --roster-source leaderboard vs live, single-pass, injected fakes
+# ---------------------------------------------------------------------------
+
+
+class _MainFakeClient:
+    """Read-only fake covering BOTH main() paths.
+
+    leaderboard path uses get_profit_leaderboard + get_positions; live path uses
+    get_trades + get_positions + get_holders. NO order/execute surface.
+    """
+
+    def __init__(
+        self,
+        *,
+        leaderboard: List[Dict[str, Any]] = None,
+        positions_by_wallet: Dict[str, List[Dict[str, Any]]] = None,
+        trades: List[Dict[str, Any]] = None,
+        holders_by_market: Dict[str, List[Dict[str, Any]]] = None,
+        market_trades: Dict[str, List[Dict[str, Any]]] = None,
+    ) -> None:
+        self._leaderboard = leaderboard or []
+        self._positions_by_wallet = positions_by_wallet or {}
+        self._trades = trades or []
+        self._holders_by_market = holders_by_market or {}
+        self._market_trades = market_trades or {}
+
+    def get_profit_leaderboard(self, window: str = "all", limit: int = 100):
+        return self._leaderboard
+
+    def get_positions(self, user: str, limit: int = 500):
+        return self._positions_by_wallet.get(user, [])
+
+    def get_trades(self, user: Any = None, market: Any = None,
+                   limit: int = 100, offset: int = 0):
+        if market is not None:
+            return self._market_trades.get(market, [])
+        # Global feed paged by offset (live discovery walks pages).
+        return self._trades if offset == 0 else []
+
+    def get_holders(self, market_condition_id: str, limit: int = 100):
+        return self._holders_by_market.get(market_condition_id, [])
+
+
+class MainTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self._tmp.name, "pnl_ledger.jsonl")
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _run_main(self, fake: "_MainFakeClient", argv: List[str]) -> int:
+        """Run main() with PolymarketDataAPIClient swapped for ``fake``."""
+        import exchanges.polymarket_data_api as data_api_mod
+        original = data_api_mod.PolymarketDataAPIClient
+        data_api_mod.PolymarketDataAPIClient = lambda *a, **k: fake
+        try:
+            return runner.main(argv + ["--ledger-path", self.path])
+        finally:
+            data_api_mod.PolymarketDataAPIClient = original
+
+    def test_leaderboard_mode_logs_candidate_with_confidence(self) -> None:
+        # Two leaderboard winners both CURRENTLY hold 0xCONV idx 0 -> converge.
+        # A current /trades mark on that outcome gives a real entry price.
+        fake = _MainFakeClient(
+            leaderboard=[
+                {"proxyWallet": "0xW1", "amount": 9e6, "name": "Theo4"},
+                {"proxyWallet": "0xW2", "amount": 5e5, "name": "WhaleTwo"},
+            ],
+            positions_by_wallet={
+                "0xW1": [
+                    _position(condition_id="0xCONV", outcome_index=0,
+                              outcome="Yes"),
+                    # a settled win so confidence sees a real win-rate
+                    _position(condition_id="0xSET", outcome_index=0,
+                              redeemable=True, cur_price=1.0, realized_pnl=10.0),
+                ],
+                "0xW2": [
+                    _position(condition_id="0xCONV", outcome_index=0,
+                              outcome="Yes"),
+                ],
+            },
+            market_trades={
+                "0xCONV": [_trade(0, 0.61, timestamp=500)],
+            },
+        )
+
+        rc = self._run_main(
+            fake,
+            ["--roster-source", "leaderboard", "--min-convergence", "2",
+             "--leaderboard-limit", "10"],
+        )
+        self.assertEqual(rc, 0)
+
+        ledger = PnlLedger(self.path)
+        records = ledger.all_records()
+        self.assertEqual(len(records), 1)
+        rec = records[0]
+        self.assertEqual(rec.market_id, "0xCONV")
+        self.assertEqual(rec.side, "Yes")
+        self.assertEqual(rec.strategy, STRATEGY)
+        self.assertEqual(rec.status, "open")
+        # Real decision-time entry mark from /trades.
+        self.assertEqual(rec.entry_price, 0.61)
+        # Confidence marker present in notes (the leaderboard path scores it).
+        self.assertRegex(rec.notes, r"confidence=[0-9.]+ \((low|medium|high)\)")
+        self.assertIn("SHADOW MODE - NO ORDERS", rec.notes)
+        for w in ("0xW1", "0xW2"):
+            self.assertIn(w, rec.notes)
+
+    def test_leaderboard_mode_no_convergence_logs_nothing(self) -> None:
+        fake = _MainFakeClient(
+            leaderboard=[{"proxyWallet": "0xW1", "amount": 1.0}],
+            positions_by_wallet={
+                "0xW1": [_position(condition_id="0xCONV", outcome_index=0)],
+            },
+        )
+        rc = self._run_main(
+            fake, ["--roster-source", "leaderboard", "--min-convergence", "2"]
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual(PnlLedger(self.path).all_records(), [])
+
+    def test_live_mode_still_works_as_before(self) -> None:
+        # Live path: discover wallets from /trades, rank by /positions, derive
+        # hot markets, flag convergence on /holders. Two ranked wallets converge.
+        ranked_positions = [
+            _position(condition_id=f"0xH{i}", outcome_index=0, outcome="Yes",
+                      redeemable=True, cur_price=1.0, realized_pnl=5.0)
+            for i in range(20)
+        ]
+        fake = _MainFakeClient(
+            trades=[
+                {"proxyWallet": "0xA", "conditionId": "0xHOT"},
+                {"proxyWallet": "0xB", "conditionId": "0xHOT"},
+                {"proxyWallet": "0xC", "conditionId": "0xHOT"},
+            ],
+            positions_by_wallet={
+                "0xA": ranked_positions,
+                "0xB": ranked_positions,
+                "0xC": ranked_positions,
+            },
+            holders_by_market={
+                "0xHOT": _holders_groups(["0xA", "0xB", "0xC"], []),
+            },
+            market_trades={"0xHOT": [_trade(0, 0.44, timestamp=300)]},
+        )
+
+        rc = self._run_main(
+            fake,
+            ["--roster-source", "live", "--min-convergence", "3",
+             "--min-settled", "20", "--min-win-rate", "0.60",
+             "--discover-pages", "1", "--max-markets", "5"],
+        )
+        self.assertEqual(rc, 0)
+
+        records = PnlLedger(self.path).all_records()
+        self.assertEqual(len(records), 1)
+        rec = records[0]
+        self.assertEqual(rec.market_id, "0xHOT")
+        self.assertEqual(rec.side, "Yes")
+        self.assertEqual(rec.entry_price, 0.44)
+        self.assertEqual(rec.strategy, STRATEGY)
 
 
 if __name__ == "__main__":

--- a/tests/prediction_market_scanner/test_whale_follow_runner.py
+++ b/tests/prediction_market_scanner/test_whale_follow_runner.py
@@ -838,6 +838,105 @@ class MainTest(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertEqual(PnlLedger(self.path).all_records(), [])
 
+    def test_settlement_on_by_default_closes_resolved_position(self) -> None:
+        # Seed an OPEN whale position whose market has since RESOLVED (won).
+        # On the next main() run (settlement ON by default) it must be settled.
+        seed = PnlLedger(self.path)
+        seed.append(
+            TradeRecord(
+                trade_id="whale-seed",
+                ts_utc="2026-06-01T00:00:00+00:00",
+                venue="polymarket",
+                market_id="0xRESOLVED",
+                side="Yes",
+                entry_price=0.50,
+                size=100.0,
+                fees_usd=0.0,
+                slippage_bps=0.0,
+                strategy=STRATEGY,
+                status="open",
+                notes="SHADOW MODE - NO ORDERS; whale_convergence n=3 "
+                "outcomeIndex=0; entry_price=0.5000; wallets=0xT1,0xT2,0xT3",
+            )
+        )
+
+        # No convergence this run (empty leaderboard) — we only care about the
+        # settlement sweep firing.
+        fake = _MainFakeClient(leaderboard=[])
+
+        import exchanges.polymarket_market_data as mkt_mod
+        original = mkt_mod.get_market_resolution
+        mkt_mod.get_market_resolution = lambda cid: (
+            {"closed": True,
+             "tokens": [
+                 {"outcome": "Yes", "price": 1.0, "winner": True},
+                 {"outcome": "No", "price": 0.0, "winner": False},
+             ]}
+            if cid == "0xRESOLVED"
+            else None
+        )
+        try:
+            rc = self._run_main(fake, ["--roster-source", "leaderboard"])
+        finally:
+            mkt_mod.get_market_resolution = original
+        self.assertEqual(rc, 0)
+
+        ledger = PnlLedger(self.path)
+        settled = ledger.settled()
+        self.assertEqual(len(settled), 1)
+        rec = settled[0]
+        self.assertEqual(rec.trade_id, "whale-seed")
+        self.assertEqual(rec.exit_price, 1.0)
+        self.assertEqual(rec.market_outcome, "won:Yes")
+        self.assertAlmostEqual(rec.realized_pnl_usd, 96.0, places=4)
+        self.assertEqual(ledger.open_positions(), [])
+
+    def test_no_settle_flag_leaves_resolved_position_open(self) -> None:
+        # Same seed, but --no-settle: the resolver must never be consulted and
+        # the position stays open.
+        seed = PnlLedger(self.path)
+        seed.append(
+            TradeRecord(
+                trade_id="whale-seed",
+                ts_utc="2026-06-01T00:00:00+00:00",
+                venue="polymarket",
+                market_id="0xRESOLVED",
+                side="Yes",
+                entry_price=0.50,
+                size=100.0,
+                fees_usd=0.0,
+                slippage_bps=0.0,
+                strategy=STRATEGY,
+                status="open",
+                notes="SHADOW MODE - NO ORDERS; whale_convergence n=3 "
+                "outcomeIndex=0; entry_price=0.5000; wallets=0xT1",
+            )
+        )
+        fake = _MainFakeClient(leaderboard=[])
+
+        import exchanges.polymarket_market_data as mkt_mod
+        calls: List[str] = []
+        original = mkt_mod.get_market_resolution
+
+        def _spy(cid: str):
+            calls.append(cid)
+            return {"closed": True, "tokens": [{"winner": True}, {"winner": False}]}
+
+        mkt_mod.get_market_resolution = _spy
+        try:
+            rc = self._run_main(
+                fake, ["--roster-source", "leaderboard", "--no-settle"]
+            )
+        finally:
+            mkt_mod.get_market_resolution = original
+        self.assertEqual(rc, 0)
+
+        # --no-settle: resolver untouched, position still open.
+        self.assertEqual(calls, [])
+        ledger = PnlLedger(self.path)
+        self.assertEqual(len(ledger.open_positions()), 1)
+        self.assertEqual(ledger.settled(), [])
+
     def test_live_mode_still_works_as_before(self) -> None:
         # Live path: discover wallets from /trades, rank by /positions, derive
         # hot markets, flag convergence on /holders. Two ranked wallets converge.

--- a/tests/prediction_market_scanner/test_whale_follow_runner.py
+++ b/tests/prediction_market_scanner/test_whale_follow_runner.py
@@ -529,10 +529,12 @@ class ConvergenceFromPositionsTest(unittest.TestCase):
         self.assertEqual(cand["outcome"], "Yes")
         self.assertEqual(cand["n_target_holders"], 2)
         self.assertEqual(set(cand["wallets"]), {"0xT1", "0xT2"})
-        # Candidate shape matches find_convergence exactly.
+        # Candidate shape is the find_convergence shape plus a ``title`` (carried
+        # from /positions so the do-not-trade blocklist can match on it).
         self.assertEqual(
             set(cand),
-            {"conditionId", "outcomeIndex", "outcome", "n_target_holders", "wallets"},
+            {"conditionId", "outcomeIndex", "outcome", "title",
+             "n_target_holders", "wallets"},
         )
 
     def test_resolved_and_redeemable_positions_excluded(self) -> None:


### PR DESCRIPTION
Bundles everything that PR #13 merged short of (it landed at the confidence commit `30cf0dd`) PLUS the two new operator-requested guards. All SHADOW-ONLY, no order code.

## Carried forward (were stranded on the feature branch, not in main)
- **Leaderboard roster + positions-based convergence**: rank from `lb-api.polymarket.com/profit` (real top winners), detect convergence from each winner's CURRENT `/positions` (excludes settled — no look-ahead). `--roster-source {live,leaderboard}`.
- **Confidence recalibration**: leaderboard mode scores quality on profit-rank (elite floor), so 3-4 top winners co-holding reads medium/high, not low.

## New in this PR
- **Do-not-trade blocklist** (`src/trade_blocklist.py`): exclude markets matching blocked terms. Built-in defaults: alcohol / casino-gambling / adult content. Extend via `--blocklist-file`. Whole-word, case-insensitive (no 'wine'/'winner' false positives). Exclusions counted + printed, never silent. `--no-blocklist` to disable.
- **Dedup** (default on): never log a 2nd open position for a `(market, outcome)` already open, so the 30-min loop stops piling up duplicates of the same convergence. `--no-dedup` to disable.

## Verified live
Run 1 logged 4 convergences; run 2 on the same ledger logged 0, skipped 4 already-open duplicates. Blocklist active (30 terms), matching unit-tested. 140 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)